### PR TITLE
Add list-numbers option

### DIFF
--- a/sympy-bot
+++ b/sympy-bot
@@ -28,7 +28,9 @@ def main():
 Commands:
 
   review NNN            Reviews the pull request NNN
-  list                  Lists all open pull requests""")
+  list                  Lists all open pull requests
+  list-numbers          Lists only the numbers of open pull requests;
+                        Suitable for piping into xargs sympy-bot review""")
     parser.add_option("-n", "--no-upload",
             action="store_false", dest="upload",
             default=True, help="Do not upload the results into the pull request")
@@ -41,6 +43,9 @@ Commands:
         arg, = args
         if arg == "list":
             list_pull_requests()
+            return
+        elif arg == "list-numbers":
+            list_pull_requests(numbers_only=True)
             return
         print "Unknown command"
         sys.exit(1)
@@ -154,9 +159,13 @@ def pastehtml_upload(source, input_type="html"):
         s = s[s.find("http", 2):]
     return s
 
-def list_pull_requests():
+def list_pull_requests(numbers_only=False):
     p = github_get_pull_request_all()
     pulls = []
+    if numbers_only:
+        for pull in p['pulls']:
+            print pull['number']
+        return
     for pull in p['pulls']:
         n = pull['number']
         repo = pull['head']['repository']['url']


### PR DESCRIPTION
This lists only the numbers, which you can then pipe into xargs
./sympy-bot review to review all pull requests.  Just piping list into
tools like cut doesn't work because of unicode problems.
