### PR TITLE
Python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,8 @@ adding the following lines to it::
     user = "your user name"
     token = "your GitHub API token"
     reference = "path to a local clone of SymPy's repository"
+    testcommand = "command to run tests with (default is './setup.py test')
+
 Note that with configuration file you can use only token-based GitHub
 authentication mechanism (this is for your safety, but anyway make sure
 that the configuration file has proper permissions assigned, e.g. 600).

--- a/README.rst
+++ b/README.rst
@@ -46,9 +46,9 @@ adding the following lines to it::
     user = "your user name"
     token = "your GitHub API token"
     reference = "path to a local clone of SymPy's repository"
-
-Note that with configuration file you can use only token-based GitHub authentication
-mechanism (this is for your safety, but anyway make sure that the configuration file
-has proper permissions assigned, e.g. 600). If you don't want to use a reference to
-a local clone of SymPy's repository, then simply don't include ``reference`` field in
-the configuration file or leave it's value empty (``reference = ""``).
+Note that with configuration file you can use only token-based GitHub
+authentication mechanism (this is for your safety, but anyway make sure
+that the configuration file has proper permissions assigned, e.g. 600).
+You may leave any value that you don't want to include empty, and the
+default will be used.  If you supply a username and not an API token,
+then sympy-bot will ask you for your GitHub password on each invocation.

--- a/README.rst
+++ b/README.rst
@@ -54,3 +54,6 @@ that the configuration file has proper permissions assigned, e.g. 600).
 You may leave any value that you don't want to include empty, and the
 default will be used.  If you supply a username and not an API token,
 then sympy-bot will ask you for your GitHub password on each invocation.
+
+You can get your GitHub API token by going to
+https://github.com/account/admin.

--- a/other/sympy-next.py
+++ b/other/sympy-next.py
@@ -3,7 +3,7 @@
 # Tool to aggeregrate several branches, automatically merge them (if possible)
 # and create statistics about unit tests.
 #
-# usage: sympy-next.py <options>                          
+# usage: sympy-next.py <options>
 #        --help            -h  This message
 #        --verbose         -v  Enable verbose output
 #        --no-test         -n  Only recreate output
@@ -49,6 +49,7 @@ def read_branchfile(f):
 
 def run_tests():
     logit("Running unit tests.")
+    logit("Command: " + ' '.join(command))
     out = subprocess.Popen(command, stdout=subprocess.PIPE).stdout
 
     report = []

--- a/sympy-bot
+++ b/sympy-bot
@@ -319,11 +319,14 @@ def review(n, upload=False, reference=None):
     log_file = "%s/out/log" % tmpdir
     print "View report at: %s" % report_file
     print "View log at: %s" % log_file
-    print "> Uploading test results"
     report = open(report_file).read()
-    report_url = pastehtml_upload(report, input_type="html")
-    print "> Uploaded report at: %s" % report_url
-    review = formulate_review(report_url, report, user)
+    if upload:
+        print "> Uploading test results"
+        report_url = pastehtml_upload(report, input_type="html")
+        print "> Uploaded report at: %s" % report_url
+        review = formulate_review(report_url, report, user)
+    else:
+        review = formulate_review("(report was not uploaded)", report, user)
     print "> Review:"
     print review
     if upload:

--- a/sympy-bot
+++ b/sympy-bot
@@ -244,39 +244,44 @@ https to authenticate with GitHub, otherwise not saved anywhere else:\
 """
 
 def github_authenticate(config):
-    try:
-        username = config['user'] + '/token'
-        password = config['token']
-    except KeyError:
-        pass
+    def get_password():
+        try:
+            while True:
+                password = getpass("Password: ")
+
+                try:
+                    print "> Checking username and password ..."
+                    github_check_authentication(username, password)
+                except AuthenticationFailed:
+                    print ">     Authentication failed."
+                else:
+                    print ">     OK."
+                    return password
+        except KeyboardInterrupt:
+            print "\n> Quitting on signal SIGINT."
+            sys.exit(1)
+
+    if 'user' in config:
+        username = config['user']
     else:
+        username = raw_input("Username: ")
+
+    if 'token' in config:
+        username = username + '/token'
+        password = config['token']
+
         try:
             print "> Checking username and password ..."
             github_check_authentication(username, password)
         except AuthenticationFailed:
             print ">     Authentication failed."
-        else:
-            print ">     OK."
-            return username, password
+            password = get_password()
+    else:
+        password = get_password()
 
     print _login_message
 
-    try:
-        username = raw_input("Username: ")
-        while True:
-            password = getpass("Password: ")
-
-            try:
-                print "> Checking username and password ..."
-                github_check_authentication(username, password)
-            except AuthenticationFailed:
-                print ">     Authentication failed."
-            else:
-                print ">     OK."
-                return username, password
-    except KeyboardInterrupt:
-        print "\n> Quitting on signal SIGINT."
-        sys.exit(1)
+    return username, password
 
 def review(n, upload=False, reference=None):
     config = load_config_file()

--- a/sympy-bot
+++ b/sympy-bot
@@ -37,6 +37,10 @@ Commands:
     parser.add_option("-r", "--reference",
             action="store", type="str", dest="reference",
             default=None, help="Passes this to 'git clone <sympy repo>'")
+    parser.add_option("-t", "--testcommand", dest="testcommand",
+            default=None, help="Command to run tests with.  "
+            "Use this to run the tests with a different version of Python than "
+            "the default, like './sympy-bot --t 'python2.5 setup.py test'.")
     options, args = parser.parse_args()
 
     if len(args) == 1:
@@ -52,7 +56,8 @@ Commands:
     elif len(args) == 2:
         arg1, arg2 = args
         if arg1 == "review":
-            review(int(arg2), upload=options.upload, reference=options.reference)
+            review(int(arg2), upload=options.upload, reference=options.reference,
+                testcommand=options.testcommand)
             return
         print "Unknown command"
         sys.exit(1)
@@ -283,8 +288,10 @@ def github_authenticate(config):
 
     return username, password
 
-def review(n, upload=False, reference=None):
+def review(n, upload=False, reference=None, testcommand=None):
     config = load_config_file()
+    if not testcommand:
+        testcommand = config.get("testcommand", "./setup.py test")
     if upload:
         username, password = github_authenticate(config)
     tmpdir = mkdtemp(prefix='sympy-bot-tmp')
@@ -317,7 +324,8 @@ def review(n, upload=False, reference=None):
 
     print "> Running sympy-next"
     cmd("cp other/sympy-next.py %s/" % tmpdir)
-    cmd("cd %s; ./sympy-next.py -r sympy -b branches -o out -l log --verbose" % tmpdir)
+    cmd('cd %s; ./sympy-next.py -r sympy -b branches -o out -l log --verbose --command "%s"'
+        % (tmpdir, testcommand))
     print "Done."
     print
     report_file = "%s/out/report.html" % tmpdir


### PR DESCRIPTION
This lets you specify a custom test command to run the tests with.  This lets you run the tests with a different Python than the default. I recommend that everyone add `testcommand = "python2.5 setup.py test"` to their `~/.sympy/sympy-bot.conf` file.

I also added some small unrelated fixes that I made along the way.
