### PR TITLE
Fix the rename from sympy-py3k to py3k-sympy

### DIFF
--- a/other/sympy-next.py
+++ b/other/sympy-next.py
@@ -94,7 +94,7 @@ def run_tests():
 
     return report
 
-py3k = "sympy-py3k"
+py3k = "py3k-sympy"
 
 def pre_python3():
     if translate:

--- a/testrunner.py
+++ b/testrunner.py
@@ -47,7 +47,7 @@ def run_tests(master_repo_url, pull_request_repo_url, pull_request_branch,
         return {"result": "conflicts", "log": ""}
     if python3:
         cmd("cd %s; bin/use2to3" % master_repo_path)
-        master_repo_path = master_repo_path + "/sympy-py3k"
+        master_repo_path = master_repo_path + "/py3k-sympy"
     log, r = cmd2("cd %s; %s %s" % (master_repo_path,
         interpreter, test_command))
     print "Return code:", r


### PR DESCRIPTION
Merge this as soon as https://github.com/sympy/sympy/pull/671 is merged (but no sooner!).
