### PR TITLE
Added platform information to report's summary.

### DIFF
--- a/sympy-bot
+++ b/sympy-bot
@@ -110,7 +110,7 @@ Commands:
 
 def formulate_review(report_url, report_status, user, config):
     user = user.get("login", None)
-    platform_version = get_platform_version(config.interpreter)
+
     if user:
         atuser = "@"+user+": "
     else:
@@ -121,37 +121,32 @@ def formulate_review(report_url, report_status, user, config):
 %sPlease rebase or merge your branch with master.  \
 See the report for a list of the merge conflicts.""" % atuser
     elif report_status == "fetch":
-        summary = """Could not fetch the branch.  %sPlease run the sympy-bot tests again.""" % atuser
+        summary = """Could not fetch the branch.
+
+%sPlease run the sympy-bot tests again.""" % atuser
     elif report_status == "Failed":
         summary = """There were test failures.
 
-%s
-%sPlease fix the test failures.""" % (platform_version, atuser)
+%sPlease fix the test failures.""" % atuser
     elif report_status == "Passed":
-        summary = """All tests have passed.
-
-%s""" % platform_version
+        summary = """All tests have passed."""
     else:
         raise ValueError("Unknown report_status")
+
+    details  = get_platform_version(config.interpreter)
+    bold = ("", "**")[config.testcommand != default_testcommand]
+    details += """*Test command:* %s%s%s\n""" % (bold, config.testcommand, bold)
 
     report = """\
 Test results html report: %s
 """ % report_url
 
-    if config.interpreter != default_interpreter:
-        report += """
-**Note** A custom interpreter was used: `%s`
-""" % config.interpreter
-
-    if config.testcommand != default_testcommand:
-        report += """
-**Note** A custom test command was used: `%s`
-""" % config.testcommand
-
     report += """
-Summary: %s
+%s
+**Summary:** %s
 
-Automatic review by [sympy-bot](https://github.com/sympy/sympy-bot).""" % summary
+Automatic review by [sympy-bot](https://github.com/sympy/sympy-bot).""" % \
+    (details, summary)
 
     return report
 
@@ -190,10 +185,9 @@ def get_platform_version(interpreter):
     use_cache = getenv('SYMPY_USE_CACHE', 'yes').lower()
     executable = sys.executable
     python_version = get_interpreter_version_info(interpreter)
-
-    r  = "python:       %s" % python_version
-    r += "architecture: %s (%s)\n" % (platfotm_system, architecture)
-    r += "cache:        %s\n" % use_cache
+    r  = "*Interpreter:*   %s  (%s)\n" % (executable, python_version)
+    r += "*Architecture:* %s (%s)\n" % (platfotm_system, architecture)
+    r += "*Cache:*        %s\n" % use_cache
     return r
 
 

--- a/sympy-bot
+++ b/sympy-bot
@@ -109,6 +109,7 @@ Commands:
 
 def formulate_review(report_url, report_status, user, config):
     user = user.get("login", None)
+    platform_version = get_platform_version()
     if user:
         atuser = "@"+user+": "
     else:
@@ -123,9 +124,12 @@ See the report for a list of the merge conflicts.""" % atuser
     elif report_status == "Failed":
         summary = """There were test failures.
 
-%sPlease fix the test failures.""" % atuser
+%s
+%sPlease fix the test failures.""" % (platform_version, atuser)
     elif report_status == "Passed":
-        summary = """All tests have passed."""
+        summary = """All tests have passed.
+
+%s""" % platform_version
     else:
         raise ValueError("Unknown report_status")
 
@@ -169,6 +173,29 @@ def load_config_file():
                 return namespace
 
     return {}
+
+def get_platform_version():
+    import sys
+    from os import getenv
+    import platform
+    size = getattr(sys, "maxint", None)
+    if size is None: #Python 3 doesn't have maxint
+        size = sys.maxsize
+    if size > 2**32:
+        architecture = "64-bit"
+    else:
+        architecture = "32-bit"
+    platfotm_system = platform.system()
+    use_cache = getenv('SYMPY_USE_CACHE', 'yes').lower()
+    executable = sys.executable
+    v = tuple(sys.version_info)
+    python_version = "%s.%s.%s-%s-%s" % v
+
+    r  = "python:       %s\n" % python_version
+    r += "architecture: %s (%s)\n" % (platfotm_system, architecture)
+    r += "cache:        %s\n" % use_cache
+    return r
+
 
 def review(n, config):
     if config.upload:

--- a/sympy-bot
+++ b/sympy-bot
@@ -189,10 +189,9 @@ def get_platform_version(interpreter):
     platfotm_system = platform.system()
     use_cache = getenv('SYMPY_USE_CACHE', 'yes').lower()
     executable = sys.executable
-    v = get_interpreter_version_info(interpreter)
-    python_version = "%s.%s.%s-%s-%s" % v
+    python_version = get_interpreter_version_info(interpreter)
 
-    r  = "python:       %s\n" % python_version
+    r  = "python:       %s" % python_version
     r += "architecture: %s (%s)\n" % (platfotm_system, architecture)
     r += "cache:        %s\n" % use_cache
     return r

--- a/sympy-bot
+++ b/sympy-bot
@@ -15,7 +15,8 @@ import time
 
 from utils import (cmd, github_get_pull_request,
         github_authenticate, pastehtml_upload, reviews_sympy_org_upload,
-        github_add_comment_to_pull_request, list_pull_requests, format_repo)
+        github_add_comment_to_pull_request, list_pull_requests, format_repo,
+        get_interpreter_version_info)
 from testrunner import run_tests
 
 default_testcommand = "setup.py test"
@@ -109,7 +110,7 @@ Commands:
 
 def formulate_review(report_url, report_status, user, config):
     user = user.get("login", None)
-    platform_version = get_platform_version()
+    platform_version = get_platform_version(config.interpreter)
     if user:
         atuser = "@"+user+": "
     else:
@@ -174,7 +175,7 @@ def load_config_file():
 
     return {}
 
-def get_platform_version():
+def get_platform_version(interpreter):
     import sys
     from os import getenv
     import platform
@@ -188,7 +189,7 @@ def get_platform_version():
     platfotm_system = platform.system()
     use_cache = getenv('SYMPY_USE_CACHE', 'yes').lower()
     executable = sys.executable
-    v = tuple(sys.version_info)
+    v = get_interpreter_version_info(interpreter)
     python_version = "%s.%s.%s-%s-%s" % v
 
     r  = "python:       %s\n" % python_version

--- a/sympy-bot
+++ b/sympy-bot
@@ -134,7 +134,10 @@ See the report for a list of the merge conflicts.""" % atuser
         raise ValueError("Unknown report_status")
 
     details  = get_platform_version(config.interpreter)
-    bold = ("", "**")[config.testcommand != default_testcommand]
+    if config.testcommand != default_testcommand:
+        bold = "**"
+    else:
+        bold = ""
     details += """*Test command:* %s%s%s\n""" % (bold, config.testcommand, bold)
 
     report = """\

--- a/utils.py
+++ b/utils.py
@@ -76,12 +76,13 @@ def get_interpreter_version_info(interpreter):
     Get python version of `interpreter`
     """
 
-    cmd = "%s -c 'import sys; print(sys.version_info[:])'" % interpreter
+    code = 'import sys; print("%s.%s.%s-%s-%s" % sys.version_info[:])'
+    cmd = "%s -c '%s'" % (interpreter, code)
     p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT)
     ouput = p.stdout.read()
 
-    return eval(ouput)
+    return ouput
 
 def github_get_pull_request_all(repo):
     """

--- a/utils.py
+++ b/utils.py
@@ -71,6 +71,17 @@ def cmd2(cmd):
 
     return log, r
 
+def get_interpreter_version_info(interpreter):
+    """
+    Get python version of `interpreter`
+    """
+
+    cmd = "%s -c 'import sys; print(sys.version_info[:])'" % interpreter
+    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
+    ouput = p.stdout.read()
+
+    return eval(ouput)
 
 def github_get_pull_request_all(repo):
     """

--- a/utils.py
+++ b/utils.py
@@ -82,7 +82,7 @@ def get_interpreter_version_info(interpreter):
             stderr=subprocess.STDOUT)
     ouput = p.stdout.read()
 
-    return ouput
+    return ouput.strip()
 
 def github_get_pull_request_all(repo):
     """


### PR DESCRIPTION
So the python's version and architecture is showen in github
discussion directly. Like this:

```
Test results html report: http://reviews.sympy.org/report/agZzeW1weTNyDAsSBFRhc2sYv4YDDA

Summary: All tests have passed.

python: 2.6.6-final-0
architecture: Linux (64-bit)
cache: yes

Automatic review by sympy-bot.
```

In particular, it can help to others to decide with what versions
they can produce the additional test running.

Example of real usage of this is here:
https://github.com/sympy/sympy/pull/711#issuecomment-2718376
