### PR TITLE
Revert "Add the number of xpassed tests to summary."

### DIFF
--- a/sympy-bot
+++ b/sympy-bot
@@ -142,8 +142,6 @@ See the report for a list of the merge conflicts.""" % atuser
     details += """*Test command:* %s%s%s\n""" % (bold, config.testcommand, bold)
     details += """*master hash*: %s\n""" % master_hash
     details += """*branch hash*: %s\n""" % branch_hash
-    if (report_status == "Passed") and xpassed:
-        details += """*XPassed tests:* %s\n""" % len(xpassed)
 
     report = """\
 Test results html report: %s


### PR DESCRIPTION
This reverts commit 2959528e1fd12b9dfd36a1ffb869dad24491aad8.

This information is not important enough to put in the summary (it can
go in the report, if you want).

Conflicts:

```
sympy-bot
testrunner.py
```

See #69.
