### PR TITLE
Workaround script for testing all mergeable and *untested* pull requests.

### DIFF
--- a/workaround.py
+++ b/workaround.py
@@ -1,0 +1,38 @@
+from subprocess import Popen
+import re
+from urllib import urlopen
+from json import load
+
+
+############################################################################################################
+def really_ugly_solution_for_finding_the_last_test_sha(pr):
+    html_link = pr['html_url']
+    page = ''.join(urlopen(html_link).readlines())
+    search = re.search(r'<em>branch hash</em>: <a href="https://github.com/sympy/sympy/commit/(\w*)"', page)
+    if search:
+        return search.groups()[-1]
+############################################################################################################
+
+while True:
+
+    open_pr = load(urlopen('https://api.github.com/repos/sympy/sympy/pulls'))
+    for pr in open_pr:
+        more_stuff = load(urlopen(pr['url']))
+        pr.update(more_stuff)
+
+    mergeable_pr = filter(lambda p : p['mergeable'], open_pr)
+
+    to_be_tested = []
+    for pr in mergeable_pr:
+        last_test_head = really_ugly_solution_for_finding_the_last_test_sha(pr)
+        if last_test_head != pr['head']['sha']:
+            to_be_tested.append(str(pr['number']))
+
+    print to_be_tested
+    for pr in to_be_tested:
+        print 'Testing: ' + pr
+        command = ['./sympy-bot', 'review']
+        command.append(pr)
+        Popen(command).wait()
+
+    sleep(6*3600)

--- a/workaround.py
+++ b/workaround.py
@@ -1,45 +1,46 @@
-from subprocess import Popen
+from subprocess import Popen, PIPE
 from time import sleep
 import re
 from urllib import urlopen
 from json import load
 
 
-############################################################################################################
+##############################################################################
 def really_ugly_solution_for_finding_the_last_test_sha(pr):
     html_link = pr['html_url']
     page = ''.join(urlopen(html_link).readlines())
     search = re.findall(r'<em>branch hash</em>: <a href="https://github.com/sympy/sympy/commit/(\w*)"', page)
     if search:
         return search[-1]
-############################################################################################################
+##############################################################################
 
 while True:
+    try:
+        open_pr = load(urlopen('https://api.github.com/repos/sympy/sympy/pulls'))
+        for pr in open_pr:
+            more_stuff = load(urlopen(pr['url']))
+            pr.update(more_stuff)
+        print "Open PRs:"
+        print [pr['number'] for pr in open_pr]
 
-    open_pr = load(urlopen('https://api.github.com/repos/sympy/sympy/pulls'))
-    for pr in open_pr:
-        more_stuff = load(urlopen(pr['url']))
-        pr.update(more_stuff)
-    print "OPEN PRs"
-    print [pr['number'] for pr in open_pr]
+        lambd_filt = lambda pr : pr['head']['sha'] != really_ugly_solution_for_finding_the_last_test_sha(pr)
 
-    lambd_filt = lambda pr : pr['head']['sha'] != really_ugly_solution_for_finding_the_last_test_sha(pr)
-    to_be_tested = filter(lambd_filt, open_pr)
-
-    print "TO BE TESTED"
-    print [pr['number'] for pr in to_be_tested]
-    for pr in to_be_tested:
-        number = str(pr['number'])
-        print 'Testing: ' + number
-        command = ['./sympy-bot', 'review']
-        command.append(number)
-        Popen(command).wait()
-        if pr['mergeable']:
-            command = ['./sympy-bot', '-3', 'review']
-            command.append(number)
-            Popen(command).wait()
+        for pr in open_pr:
+            if not lambd_filt(pr):
+                continue
+            number = str(pr['number'])
+            print 'Testing: ' + number
             command = ['./sympy-bot', '-i', 'python2.5', 'review']
             command.append(number)
             Popen(command).wait()
+            if pr['mergeable']:
+                command = ['./sympy-bot', '-3', 'review']
+                command.append(number)
+                Popen(command).wait()
+            #Popen('rm', '-rf', '/tmp/tmp*').wait()
+            #Popen('rm', '-rf', '/tmp/sympy*').wait()
 
-    sleep(3600)
+        print 'Sleeping...'
+        #sleep(3600)
+    except Exception:
+        continue


### PR DESCRIPTION
The script uses the github api to check wich pr are mergeable (the same as `sympy review mergeable`) and **not
yet tested** (this isn't implemented in sympy-bot yet). Then it runs sympy-bot on them.

The solution is very ugly. The way to use the script is just to start it
from your sympy-bot directory.
