### PR TITLE
Move the summary to the top of the report

### DIFF
--- a/sympy-bot
+++ b/sympy-bot
@@ -146,15 +146,13 @@ See the report for a list of the merge conflicts.""" % atuser
         details += """*XPassed tests:* %s\n""" % len(xpassed)
 
     report = """\
+**SymPy-Bot Summary:** %s
+
 Test results html report: %s
-""" % report_url
 
-    report += """
 %s
-**Summary:** %s
-
-Automatic review by [sympy-bot](https://github.com/sympy/sympy-bot).""" % \
-    (details, summary)
+Automatic review by [SymPy-Bot](https://github.com/sympy/sympy-bot).""" % \
+    (summary, report_url, details,)
 
     return report
 

--- a/sympy-bot
+++ b/sympy-bot
@@ -146,12 +146,12 @@ See the report for a list of the merge conflicts.""" % atuser
         details += """*XPassed tests:* %s\n""" % len(xpassed)
 
     report = """\
-**SymPy-Bot Summary:** %s
+**SymPy Bot Summary:** %s
 
 Test results html report: %s
 
 %s
-Automatic review by [SymPy-Bot](https://github.com/sympy/sympy-bot).""" % \
+Automatic review by [SymPy Bot](https://github.com/sympy/sympy-bot).""" % \
     (summary, report_url, details,)
 
     return report


### PR DESCRIPTION
This way, it will show up in the summary of the email notification in
Gmail or any other mail program that shows the first few words of an
email as a summary.
