### PR TITLE
Add -m option to sympy-bot, allowing to specify a custom commit to merge with

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,3 +67,23 @@ You can change the remote with ``-R`` flag to sympy-bot or by setting
 ``repository`` in configuration file. The new remote doesn't have to be
 SymPy's repository, but any repository on GitHub. Note that in this case
 you man need to setup customized ``testcommand``.
+
+Custom Master Commit
+--------------------
+
+By default, sympy-bot merges with master before testing, failing if the
+merge fails.  You can customize this behavior with the ``-m`` option to
+``sympy-bot``.  Pass any valid git commit name to this option, and it
+will use it to merge the master branch.  The default is
+``origin/master``, which is the current master.  If you don't want to
+merge at all, pass ``HEAD``, which will perform a noop merge against the
+branch you are testing.
+
+If you use ``--reference``, git will pull in all commits from the local
+repository. Thus, you can merge with commits that are not in the
+official ``sympy/sympy`` repository by using this and passing the SHA1
+of the commit you want.
+
+This is also useful for using bisecting a problem with SymPy Bot.
+Simply use git to bisect in your local SymPy repository and pass the
+SHA1's it picks to ``sympy-bot -n -m``.

--- a/sympy-bot
+++ b/sympy-bot
@@ -59,6 +59,10 @@ Commands:
             default="http://reviews.sympy.org",
             help="Server to upload results. Default is "
             "'http://reviews.sympy.org'")
+    parser.add_option("-m", "--master-commit",
+            action="store", type="str", dest="master_commit",
+            default="origin/master", help="Commit to use as master for merging."  "Use 'origin/master' to use the current master (the default) "
+            "and 'HEAD' to not merge.")
 
     options, args = parser.parse_args()
     config = load_config_file()
@@ -230,7 +234,10 @@ def review(n, config):
     result = run_tests(format_repo("https://github.com/{repo}.git",
         config.repository),
             repo, branch, tmpdir + "/sympy", config.testcommand,
-            config.interpreter, config.python3)
+            config.interpreter, config.python3, config.master_commit)
+    if result["result"] == "error":
+        print "There was an error. Report not uploaded."
+        sys.exit(1)
     print "Done."
     print
     log_file = "%s/out/log" % tmpdir
@@ -277,3 +284,4 @@ def review(n, config):
 
 if __name__ == "__main__":
     main()
+    sys.exit(0)


### PR DESCRIPTION
See the addition to the README for more information.  I've also made
some small modifications to error handling, which I hope are consistant
with what was already there.

Please do at least look at the error handling stuff I added (adding `review["error"]`, and calling `sys.exit`), as I'm not sure it's the best, or fully consistant with what's already there (I didn't read the rest of the code very much).
