### PR TITLE
Implement "review all" and "review mergeable"

### DIFF
--- a/sympy-bot
+++ b/sympy-bot
@@ -95,7 +95,26 @@ Commands:
     elif len(args) >= 2:
         arg1 = args[0]
         if arg1 == "review":
-            nums = [int(x) for x in args[1:]]
+            args = args[1:]
+            if len(args) == 1:
+                if args[0] == "mergeable":
+                    print "Reviewing all *mergeable* pull requests"
+                    print
+                    nonmergeable, mergeable = list_pull_requests( \
+                            options.repository, numbers_only=True)
+                    nums = mergeable
+                elif args[0] == "all":
+                    print "Reviewing *all* pull requests"
+                    print
+                    nonmergeable, mergeable = list_pull_requests( \
+                            options.repository, numbers_only=True)
+                    nums = nonmergeable + mergeable
+                else:
+                    # just a pull request #, convert it:
+                    nums = [int(args[0])]
+            else:
+                # list of pull request numbers, convert it:
+                nums = [int(x) for x in args]
             if options.upload:
                 username, password = github_authenticate(options)
             else:

--- a/utils.py
+++ b/utils.py
@@ -180,6 +180,12 @@ def reviews_sympy_org_upload(data, url_base):
     return r["task_url"]
 
 def list_pull_requests(repo, numbers_only=False):
+    """
+    Returns the pull requests numbers.
+
+    It returns a tuple of (nonmergeable, mergeable), where "nonmergeable"
+    and "mergeable" are lists of the pull requests numbers.
+    """
     p = github_get_pull_request_all(repo)
     pulls = []
     for pull in p['pulls']:
@@ -195,8 +201,10 @@ def list_pull_requests(repo, numbers_only=False):
         pulls.append((created_at, n, repo, branch, author, mergeable))
     pulls.sort(key=lambda x: x[0])
     print "Patches that cannot be merged without conflicts:"
+    nonmergeable = []
     for created_at, n, repo, branch, author, mergeable in pulls:
         if mergeable: continue
+        nonmergeable.append(int(n))
         if numbers_only:
             print n,
         else:
@@ -208,8 +216,10 @@ def list_pull_requests(repo, numbers_only=False):
     print
     print "-"*80
     print "Patches that can be merged without conflicts:"
+    mergeable_list = []
     for last_change, n, repo, branch, author, mergeable in pulls:
         if not mergeable: continue
+        mergeable_list.append(int(n))
         if numbers_only:
             print n,
         else:
@@ -218,6 +228,7 @@ def list_pull_requests(repo, numbers_only=False):
             print "      Date     : %s" % time.ctime(last_change)
     if numbers_only:
         print
+    return nonmergeable, mergeable_list
 
 _login_message = """\
 Enter your GitHub username & password or press ^C to quit. The password


### PR DESCRIPTION
Besides a list of a one or more pull request numbers, you can now also specify
"all" to review all open pull requests or "mergeable" to review all pull
requests that can be merged.

Closes #74
