### PR TITLE
Copy py3k-sympy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,13 +35,20 @@ Tips
 By default, the sympy repository is fully downloaded from the web, so you don't
 need to have any local copy. However, if you do have a local copy already, you
 can skip most of the download (which might take a few minutes on slower
-connections) by passing a ``--reference`` option to sympy-bot::
+connection) by passing a ``--reference`` option to sympy-bot::
 
     ./sympy-bot --reference ~/repo/git/sympy review 268
 
 This gets passed to git, see ``git clone --help`` for more information. Then
-sympy-bot starts testing the branch immediately, even if you have a slower
+sympy-bot starts testing the branch immediately, especially if you have a slower
 connections.
+
+This has another advantage: if you run ``./use/2to3`` in the reference
+directory, the ``py3k-sympy`` directory will be copied over to the testing
+directory, saving time (only those files that are changed by the pull request
+will have to be converted by 2to3 again).  If you want to disable this, add
+the ``--py3k-no-copy`` option to sympy-bot, or add ``py3k_no_copy = True`` to
+your ``sympy-bot.conf`` file (see the next section).
 
 Configuration
 -------------

--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,8 @@ connection) by passing a ``--reference`` option to sympy-bot::
     ./sympy-bot --reference ~/repo/git/sympy review 268
 
 This gets passed to git, see ``git clone --help`` for more information. Then
-sympy-bot starts testing the branch immediately, especially if you have a slower
-connections.
+sympy-bot starts testing the branch immediately, even if you have a slower
+connection.
 
 This has another advantage: if you run ``./use/2to3`` in the reference
 directory, the ``py3k-sympy`` directory will be copied over to the testing

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ This gets passed to git, see ``git clone --help`` for more information. Then
 sympy-bot starts testing the branch immediately, even if you have a slower
 connection.
 
-This has another advantage: if you run ``./use/2to3`` in the reference
+This has another advantage: if you run ``./bin/use2to3`` in the reference
 directory, the ``py3k-sympy`` directory will be copied over to the testing
 directory, saving time (only those files that are changed by the pull request
 will have to be converted by 2to3 again).  If you want to disable this, add

--- a/sympy-bot
+++ b/sympy-bot
@@ -16,7 +16,7 @@ import time
 from utils import (cmd, github_get_pull_request,
         github_authenticate, pastehtml_upload, reviews_sympy_org_upload,
         github_add_comment_to_pull_request, list_pull_requests, format_repo,
-        get_interpreter_version_info)
+        get_interpreter_version_info, CmdException)
 from testrunner import run_tests
 
 default_testcommand = "setup.py test"
@@ -249,7 +249,11 @@ def review(n, config, username=None, password=None):
         cmd(format_repo("cd %s; git clone --reference %s git://github.com/{repo}.git", config.repository) % (tmpdir, reference))
         if config.python3 and not config.py3k_no_copy:
             print "> Copying py3k-sympy directory"
-            cmd("cp -R %s/py3k-sympy %s/sympy/" % (reference, tmpdir))
+            try:
+                cmd("cp -R %s/py3k-sympy %s/sympy/" % (reference, tmpdir))
+            except CmdException:
+                print "> Could not copy the py3k-sympy directory from %s. It probably doesn't exist." % reference
+                print "  Run ./bin/2to3 in that directory to generate this directory, which will make this go much faster."
     else:
         cmd(format_repo("cd %s; git clone git://github.com/{repo}.git",
             config.repository) % tmpdir)

--- a/sympy-bot
+++ b/sympy-bot
@@ -63,6 +63,9 @@ Commands:
             action="store", type="str", dest="master_commit",
             default="origin/master", help="Commit to use as master for merging."  "Use 'origin/master' to use the current master (the default) "
             "and 'HEAD' to not merge.")
+    parser.add_option("--py3k-no-copy",
+            action="store_true", default=False, dest="py3k_no_copy",
+            help="Do not copy the py3k-sympy directory (only applies if --reference is given).")
 
     options, args = parser.parse_args()
     config = load_config_file()
@@ -75,7 +78,8 @@ Commands:
         options.testcommand = config.get("testcommand", default_testcommand)
     if options.interpreter is None:
         options.interpreter = config.get("interpreter", default_interpreter)
-
+    if options.py3k_no_copy is None:
+        options.py3k_no_copy = config.get("py3k_no_copy")
     if options.python3:
         options.interpreter = "python3"
 
@@ -243,6 +247,9 @@ def review(n, config, username=None, password=None):
     if config.reference:
         reference = os.path.abspath(os.path.expanduser(os.path.expandvars(config.reference)))
         cmd(format_repo("cd %s; git clone --reference %s git://github.com/{repo}.git", config.repository) % (tmpdir, reference))
+        if config.python3 and not config.py3k_no_copy:
+            print "> Copying py3k-sympy directory"
+            cmd("cp -R %s/py3k-sympy %s/sympy/" % (reference, tmpdir))
     else:
         cmd(format_repo("cd %s; git clone git://github.com/{repo}.git",
             config.repository) % tmpdir)


### PR DESCRIPTION
Automatically copy py3k-sympy when the `--reference` option is given.

This makes running the tests in Python 3 **way** faster if you have already run `./bin/use2to3` in the reference directory, because it will just have to run 2to3 on those files that the pull request changed (and those that changed since you last ran 2to3, so it's good to just run that often, to keep things up-to-date). 

You can explicitly disable this with the `--py3k-no-copy` option, which can also be set in the config file.  

For those running tests automatically on servers (@Krastanov and @certik), I recommend adding some kind of cron job to run use2to3 on your local SymPy periodically, to keep this fast.
