### PR TITLE
Fix printing of custom interpreter path

### DIFF
--- a/sympy-bot
+++ b/sympy-bot
@@ -203,6 +203,17 @@ def load_config_file():
 
     return {}
 
+def get_executable(interpreter):
+    path = os.environ['PATH']
+    paths = path.split(os.pathsep)
+    if os.path.isfile(interpreter):
+        return interpreter
+    else:
+        for p in paths:
+            f = os.path.join(p, interpreter)
+            if os.path.isfile(f):
+                return f
+
 def get_platform_version(interpreter):
     import sys
     from os import getenv
@@ -216,7 +227,7 @@ def get_platform_version(interpreter):
         architecture = "32-bit"
     platfotm_system = platform.system()
     use_cache = getenv('SYMPY_USE_CACHE', 'yes').lower()
-    executable = sys.executable
+    executable = get_executable(interpreter)
     python_version = get_interpreter_version_info(interpreter)
     r  = "*Interpreter:*   %s  (%s)\n" % (executable, python_version)
     r += "*Architecture:* %s (%s)\n" % (platfotm_system, architecture)


### PR DESCRIPTION
Even when sympy-bot is run with a custom interpreter, it uses the path of the current executable in creating the text of the comment, see [1] which was run with 2.5 but printed the path of the 2.7 executable. This slightly changes my output, as now the default lists `/usr/bin/python` instead of `/usr/bin/python2.7` (which is still correct, and the version printing makes up for any ambiguity), but it fixes the output when using `-i python2.5` so that it prints `/usr/bin/python2.5`. To see the effect of this fix, see [2].

I have only tested this with linux and can really only guarantee it works for me, so any other testing would be greatly appreciated. It can be quickly checked by adding the `-n` flag to not upload and setting the test command to do a fast test, like `-t 'bin/test sympy/physics/quantum/tests/test_constants.py'`, then looking at what is listed as the Interpreter in the command line output.

[1] https://github.com/sympy/sympy/pull/874#issuecomment-3334831
[2] https://github.com/sympy/sympy/pull/908#issuecomment-3335785
