### PR TITLE
Fixes to be able to run upon windows XP.

### DIFF
--- a/sympy-bot
+++ b/sympy-bot
@@ -258,9 +258,9 @@ def review(n, config, username=None, password=None):
 
     if config.reference:
         reference = os.path.abspath(os.path.expanduser(os.path.expandvars(config.reference)))
-        cmd(format_repo("cd %s; git clone --reference %s git://github.com/{repo}.git", config.repository) % (tmpdir, reference))
+        cmd(format_repo("cd %s && git clone --reference %s git://github.com/{repo}.git", config.repository) % (tmpdir, reference))
     else:
-        cmd(format_repo("cd %s; git clone git://github.com/{repo}.git",
+        cmd(format_repo("cd %s && git clone git://github.com/{repo}.git",
             config.repository) % tmpdir)
 
     print "> Testing..."

--- a/sympy-bot
+++ b/sympy-bot
@@ -287,7 +287,11 @@ def review(n, config, username=None, password=None):
     master_hash = result["master_hash"]
     branch_hash = result["branch_hash"]
 
-    cmd("mkdir -p %s" % os.path.join(tmpdir, "out"))
+    if os.name=='nt':
+        mkdir_command = "mkdir"
+    else:
+        mkdir_command = "mkdir -p"
+    cmd("%s %s" % (mkdir_command, os.path.join(tmpdir, "out")))
     open(log_file, "w").write(log)
     if config.upload:
         print "> Uploading test results"

--- a/sympy-bot
+++ b/sympy-bot
@@ -187,7 +187,10 @@ Automatic review by [SymPy Bot](https://github.com/sympy/sympy-bot).""" % \
     return report
 
 def load_config_file():
-    conf_file = os.path.expanduser('~/.sympy/sympy-bot.conf')
+    conf_file = os.path.normpath('.sympy/sympy-bot.conf')
+    conf_file = os.path.join('~', conf_file)
+    conf_file = os.path.expanduser(conf_file)
+    print conf_file
 
     if os.path.exists(conf_file):
         namespace = {}
@@ -273,7 +276,7 @@ def review(n, config, username=None, password=None):
         sys.exit(1)
     print "Done."
     print
-    log_file = "%s/out/log" % tmpdir
+    log_file = os.path.join("%s" % tmpdir, "out", "log")
     print "View log at: %s" % log_file
     log = result["log"]
     report_status = result["result"]
@@ -284,7 +287,7 @@ def review(n, config, username=None, password=None):
     master_hash = result["master_hash"]
     branch_hash = result["branch_hash"]
 
-    cmd("mkdir -p %s/out" % tmpdir)
+    cmd("mkdir -p %s" % os.path.join(tmpdir, "out"))
     open(log_file, "w").write(log)
     if config.upload:
         print "> Uploading test results"

--- a/sympy-bot
+++ b/sympy-bot
@@ -16,7 +16,7 @@ import time
 from utils import (cmd, github_get_pull_request,
         github_authenticate, pastehtml_upload, reviews_sympy_org_upload,
         github_add_comment_to_pull_request, list_pull_requests, format_repo,
-        get_interpreter_version_info)
+        get_interpreter_version_info, get_interpreter_exe)
 from testrunner import run_tests
 
 default_testcommand = "setup.py test"
@@ -212,6 +212,9 @@ def load_config_file():
 def get_executable(interpreter):
     path = os.environ['PATH']
     paths = path.split(os.pathsep)
+    interpreter_exe = None
+    if os.name=="nt":
+        return get_interpreter_exe(interpreter)
     if os.path.isfile(interpreter):
         return interpreter
     else:
@@ -239,7 +242,6 @@ def get_platform_version(interpreter):
     r += "*Architecture:* %s (%s)\n" % (platfotm_system, architecture)
     r += "*Cache:*        %s\n" % use_cache
     return r
-
 
 def review(n, config, username=None, password=None):
     tmpdir = mkdtemp(prefix='sympy-bot-tmp')

--- a/testrunner.py
+++ b/testrunner.py
@@ -43,35 +43,35 @@ def run_tests(master_repo_url, pull_request_repo_url, pull_request_branch,
     print "test_command =", test_command
     print "interpreter =", interpreter
     try:
-        cmd("cd %s; git fetch %s %s:test" % (master_repo_path,
+        cmd("cd %s && git fetch %s %s:test" % (master_repo_path,
             pull_request_repo_url, pull_request_branch), echo=True)
     except CmdException:
         result["result"] = "fetch"
         return result
-    cmd("cd %s; git checkout test" % master_repo_path, echo=True)
+    cmd("cd %s && git checkout test" % master_repo_path, echo=True)
     # remember the hashes before the merge occurs:
     try:
-        result["master_hash"] = cmd("cd %s; git rev-parse %s" % (master_repo_path,
+        result["master_hash"] = cmd("cd %s && git rev-parse %s" % (master_repo_path,
             master_commit), capture=True).strip()
     except CmdException:
         print "Could not parse commit %s." % master_commit
         result["result"]= "error"
         return result
-    result["branch_hash"] = cmd("cd %s; git rev-parse test" % master_repo_path,
+    result["branch_hash"] = cmd("cd %s && git rev-parse test" % master_repo_path,
             capture=True).strip()
 
-    merge_log, r = cmd2("cd %s; git merge %s" % (master_repo_path,
+    merge_log, r = cmd2("cd %s && git merge %s" % (master_repo_path,
         master_commit))
     if r != 0:
-        conflicts = cmd("cd %s; git --no-pager diff" % master_repo_path,
+        conflicts = cmd("cd %s && git --no-pager diff" % master_repo_path,
                 capture=True)
         result["result"] = "conflicts"
         result["log"] = merge_log + "\nLIST OF CONFLICTS\n" + conflicts
         return result
     if python3:
-        cmd("cd %s; bin/use2to3" % master_repo_path)
+        cmd("cd %s && bin/use2to3" % master_repo_path)
         master_repo_path = master_repo_path + "/py3k-sympy"
-    log, r = cmd2("cd %s; %s %s" % (master_repo_path,
+    log, r = cmd2("cd %s && %s %s" % (master_repo_path,
         interpreter, test_command))
     result["log"] = log
     result["return_code"] = r

--- a/testrunner.py
+++ b/testrunner.py
@@ -69,7 +69,7 @@ def run_tests(master_repo_url, pull_request_repo_url, pull_request_branch,
         result["log"] = merge_log + "\nLIST OF CONFLICTS\n" + conflicts
         return result
     if python3:
-        cmd("cd %s && bin/use2to3" % master_repo_path)
+        cmd("cd %s && python bin/use2to3" % master_repo_path)
         master_repo_path = master_repo_path + "/py3k-sympy"
     log, r = cmd2("cd %s && %s %s" % (master_repo_path,
         interpreter, test_command))

--- a/utils.py
+++ b/utils.py
@@ -77,8 +77,8 @@ def get_interpreter_version_info(interpreter):
     Get python version of `interpreter`
     """
 
-    code = 'import sys; print("%s.%s.%s-%s-%s" % sys.version_info[:])'
-    cmd = "%s -c '%s'" % (interpreter, code)
+    code = "import sys; print('%s.%s.%s-%s-%s' % sys.version_info[:])"
+    cmd = '%s -c "%s"' % (interpreter, code)
     p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT)
     ouput = p.stdout.read()

--- a/utils.py
+++ b/utils.py
@@ -209,7 +209,7 @@ def list_pull_requests(repo, numbers_only=False):
             print n,
         else:
             print "#%03d: %s %s" % (n, repo, branch)
-            print "      Author   : %s" % author
+            print unicode("      Author   : %s" % author).encode('utf8')
             print "      Date     : %s" % time.ctime(created_at)
     if numbers_only:
         print
@@ -224,7 +224,7 @@ def list_pull_requests(repo, numbers_only=False):
             print n,
         else:
             print "#%03d: %s %s" % (n, repo, branch)
-            print "      Author   : %s" % author
+            print unicode("      Author   : %s" % author).encode('utf8')
             print "      Date     : %s" % time.ctime(last_change)
     if numbers_only:
         print

--- a/utils.py
+++ b/utils.py
@@ -85,6 +85,19 @@ def get_interpreter_version_info(interpreter):
 
     return ouput.strip()
 
+def get_interpreter_exe(interpreter):
+    """
+    Get python executable path for 'nt'
+    """
+
+    code = "import sys; print(sys.executable)"
+    cmd = '%s -c "%s"' % (interpreter, code)
+    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
+    ouput = p.stdout.read()
+
+    return ouput.strip()
+
 def get_xpassed_info_from_log(log):
     re_xpassed = re.compile("\s+_+\s+xpassed tests\s+_+\s+(?P<xpassed>([^\n]+\n)+)\n", re.M)
     m = re_xpassed.search(log)


### PR DESCRIPTION
It is related with the lines like 'cmd ("cd %s; git clone ...")' that is when a few commands run as one line.

In windows XP the separator must be strictly "&&" (or "&"), but not ";". 
Aaron remarks: && is better and for Unix too, as it will prevent execution of the second command if the first fails.

The second commit is related with output encodings. Author's name are sometimes unicode string, so in the  windows terminal (when it is not utf8) they must be encoded properly.
