### PR TITLE
Improve handling of python 3 interpreters and -3

### DIFF
--- a/sympy-bot
+++ b/sympy-bot
@@ -21,6 +21,7 @@ from testrunner import run_tests
 
 default_testcommand = "setup.py test"
 default_interpreter = "python"
+default_interpreter3 = "python3"
 
 def main():
     parser = OptionParser(usage="""\
@@ -79,10 +80,10 @@ Commands:
     if options.testcommand is None:
         options.testcommand = config.get("testcommand", default_testcommand)
     if options.interpreter is None:
-        options.interpreter = config.get("interpreter", default_interpreter)
-
-    if options.python3:
-        options.interpreter = "python3"
+        if options.python3:
+            options.interpreter = config.get("interpreter3", default_interpreter3)
+        else:
+            options.interpreter = config.get("interpreter", default_interpreter)
 
     options.user = config.get("user")
     options.token = config.get("token")
@@ -239,6 +240,14 @@ def get_platform_version(interpreter):
 
 
 def review(n, config, username=None, password=None):
+    # Make sure python3 is setup correctly
+    # If set Python 3 interpreter with -i, be sure python3 is True
+    if get_interpreter_version_info(config.interpreter)[0] == '3':
+        config.python3 = True
+    # If set Python 2 interpreter with -i and set -3, raise error
+    elif config.python3:
+        raise ValueError('Python 2 interpreter passed with -3 option')
+
     tmpdir = mkdtemp(prefix='sympy-bot-tmp')
     print "> Working directory: %s" % tmpdir
     pull = github_get_pull_request(config.repository, n)


### PR DESCRIPTION
Allows the specification of a Python 3 interpreter through the -i option to trigger the running of use2to3 and keeps -3 from overriding a custom Python 3 interpreter.

Now, just using -3 will use interpreter3 set in the config file with python3 as the default fallback, using a custom python 3 interpreter with -i will have use2to3 be run as if -3 is set, and using -3 with a custom interpreter will check that the interpreter is actually a python 3 interpreter and raise an exception if it is not.

This addresses #84.
