### PR TITLE
Fix comment output of 32/64-bit architecture

### DIFF
--- a/sympy-bot
+++ b/sympy-bot
@@ -234,12 +234,16 @@ def get_executable(interpreter):
                 return f
 
 def get_platform_version(interpreter):
-    import sys
     from os import getenv
     import platform
-    size = getattr(sys, "maxint", None)
-    if size is None: #Python 3 doesn't have maxint
-        size = sys.maxsize
+    code = 'import sys; print(getattr(sys, "maxint", None))'
+    call = "%s -c '%s'" % (interpreter, code)
+    size = cmd(call, capture=True)
+    if size == 'None\n': #Python 3 doesn't have maxint
+        code = 'import sys; print(sys.maxsize)'
+        call = "%s -c '%s'" % (interpreter, code)
+        size = cmd(call, capture=True)
+    size = int(size)
     if size > 2**32:
         architecture = "64-bit"
     else:


### PR DESCRIPTION
When forming the comment, the architecture information is gathered from the python interpreter running sympy-bot, not the custom interpreter. This uses the custom interpreter to determine whether the python
architecture is 32-bit or 64-bit.

See the comment [1] which reports a 64-bit architecture when the test suite is run with a 32-bit architecture, as seen in the report [2]. The fixed output is seen in the comment at [3].

I've tested this with Python 2.5 and 3.2 on Linux, both with 64-bit and 32-bit versions.

[1] https://github.com/sympy/sympy/pull/1012#issuecomment-3607221
[2] http://reviews.sympy.org/report/agZzeW1weTNyDAsSBFRhc2sYs4EKDA
[3] https://github.com/sympy/sympy/pull/1012#issuecomment-3607645
