### PR TITLE
Summary

### DIFF
--- a/sympy-bot
+++ b/sympy-bot
@@ -13,7 +13,7 @@ from utils.github import (github_add_comment_to_pull_request,
         github_authenticate, github_get_pull_request, github_get_user_info,
         github_list_pull_requests)
 from utils.reviews import reviews_sympy_org_upload
-from utils.testrunner import run_tests
+from utils.testrunner import run_tests, get_hashes, merge_branch
 from utils.url_templates import URLs
 
 default_testcommand = "setup.py test"
@@ -122,9 +122,9 @@ def main():
     for i in ("build_docs", "no_comment", "no_upload", "python2", "python3"):
         if i in config and isinstance(config[i], str):
             val = config[i].strip()
-            if val.lower() in ("true", "y", "yes"):
+            if val.lower() in {"true", "y", "yes"}:
                 config[i] = True
-            elif val.lower() in ("false", "n", "no"):
+            elif val.lower() in {"false", "n", "no"}:
                 config[i] = False
             else:
                 raise ConfigParser.Error("Unable to parse boolean configuration value for %s: %s" % (i, val))
@@ -150,9 +150,9 @@ def main():
         val = getattr(options, i)
         if isinstance(val, str):
             val = val.strip()
-            if val.lower() in ("true", "y", "yes"):
+            if val.lower() in {"true", "y", "yes"}:
                 setattr(options, i, True)
-            elif val.lower() in ("false", "n", "no"):
+            elif val.lower() in {"false", "n", "no"}:
                 setattr(options, i, False)
             else:
                 raise ArgumentTypeError("Unable to parse boolean configuration value for %s: %s" % (i, val))
@@ -246,9 +246,10 @@ def dispatch_reviews(config, urls, **kwargs):
 
     pr_numbers = config.n
     interpreters = config.interpreter
-    python3 = dict( [(i, get_interpreter_version_info(i)[0] == '3') for i in interpreters] )
+    python3 = {i: get_interpreter_version_info(i)[0] == '3' for i in interpreters}
 
     tmpdir = mkdtemp(prefix="sympy-bot-tmp")
+    repo_path = os.path.join(tmpdir, "sympy")
     print "> Working directory: %s" % tmpdir
 
     print "> Cloning %s master" % config.repository
@@ -264,6 +265,11 @@ def dispatch_reviews(config, urls, **kwargs):
     log_dir_base = os.path.join(tmpdir, "out")
     os.mkdir(log_dir_base)
     reviews = {}
+    master_hashes = {}
+    branch_hashes = {}
+    users = {}
+    branches = {}
+
     for n in pr_numbers:
         if len(pr_numbers) == 1:
             log_dir = log_dir_base
@@ -282,11 +288,30 @@ def dispatch_reviews(config, urls, **kwargs):
         user_info = github_get_user_info(urls, user)
         author = "\"%s\" <%s>" % (user_info.get("name", "unknown"),
                                   user_info.get("email", ""))
+
+        mergeinfo = merge_branch(repo_url, branch, repo_path,
+                                 config.master_commit, n)
+        if mergeinfo["result"] == 'fetch':
+            # These values shouldn't be used anyway
+            hashinfo = {"master_hash": None, "branch_hash": None}
+        else:
+            hashinfo = get_hashes(repo_path, config.master_commit, n)
+        if not hashinfo:
+            print "> There was an error. Report not uploaded."
+            sys.exit(1)
+
+        branch_hashes[n] = hashinfo['branch_hash']
+        master_hashes[n] = hashinfo['master_hash']
+        users[n] = user
+        branches[n] = branch
+
         print "> Pull request info:"
         print unicode(">     Author: %s" % author).encode('utf8')
         print ">     Repository: %s" % repo_url
         print ">     Branch: %s" % branch
+
         del pull
+        del hashinfo
 
         pull_review = {}
 
@@ -295,8 +320,10 @@ def dispatch_reviews(config, urls, **kwargs):
             # Run tests
             print "> Testing interpreter %s" % i
             command = "%s %s" % (i, config.testcommand)
-            repo_path = os.path.join(tmpdir, "sympy")
-            result = run_tests(repo_url, branch, repo_path, command,
+            if mergeinfo["result"] in {'fetch', 'conflicts'}:
+                result = mergeinfo
+            else:
+                result = run_tests(repo_url, branch, repo_path, command,
                     python3[i], config.master_commit)
             if result["result"] == "error":
                 print "> There was an error. Report not uploaded."
@@ -319,8 +346,6 @@ def dispatch_reviews(config, urls, **kwargs):
                     "interpreter": i,
                     "log": result["log"],
                     "testcommand": config.testcommand,
-                    "master_hash": result["master_hash"],
-                    "branch_hash": result["branch_hash"],
                 }
                 report_url = reviews_sympy_org_upload(data, url_base)
                 print "> Uploaded report for '%s' at: %s" % (i, report_url)
@@ -329,10 +354,7 @@ def dispatch_reviews(config, urls, **kwargs):
 
             pull_review[i] = {
                 "result" : result["result"],
-                "xpassed" : result["xpassed"],
-                "master_hash" : result["master_hash"],
-                "branch_hash" : result["branch_hash"],
-                "url" : report_url
+                "url" : report_url,
             }
             del result
             print
@@ -370,8 +392,6 @@ def dispatch_reviews(config, urls, **kwargs):
                     "interpreter": "None",
                     "log": result["log"],
                     "testcommand": config.build_docs_command,
-                    "master_hash": result["master_hash"],
-                    "branch_hash": result["branch_hash"],
                 }
                 report_url = reviews_sympy_org_upload(data, url_base)
                 print "> Uploaded report for building docs at: %s" % report_url
@@ -380,10 +400,7 @@ def dispatch_reviews(config, urls, **kwargs):
 
             pull_review["build_docs"] = {
                 "result" : result["result"],
-                "xpassed" : result["xpassed"],
-                "master_hash" : result["master_hash"],
-                "branch_hash" : result["branch_hash"],
-                "url" : report_url
+                "url" : report_url,
             }
             del result
             print
@@ -392,18 +409,19 @@ def dispatch_reviews(config, urls, **kwargs):
 
     # Summarize and comment
     for n, pull_review in reviews.iteritems():
-        report_url = dict([(i, result["url"]) for i, result in pull_review.iteritems()])
-        report_status = dict([(i, result["result"]) for i, result in pull_review.iteritems()])
-        xpassed = dict([(i, result["xpassed"]) for i, result in pull_review.iteritems()])
-        master_hash = dict([(i, result["master_hash"]) for i, result in pull_review.iteritems()])
-        branch_hash = dict([(i, result["branch_hash"]) for i, result in pull_review.iteritems()])
+        report_url = {i: result["url"] for i, result in pull_review.iteritems()}
+        report_status = {i: result["result"] for i, result in pull_review.iteritems()}
+        master_hash = master_hashes[n]
+        branch_hash = branch_hashes[n]
 
         # Generate summary
         review = formulate_review(report_status, report_url, master_hash,
-                branch_hash, config.interpreter, config.testcommand,
-                config.build_docs, config.build_docs_command, user)
+            branch_hash, config.interpreter, config.testcommand,
+            config.build_docs, config.build_docs_command, users[n],
+            branches[n], config.master_commit)
 
         print "> Review:"
+        print
         print review
         print
 
@@ -415,88 +433,90 @@ def dispatch_reviews(config, urls, **kwargs):
             print ">     Done."
             print "> Check the results: https://github.com/%s/pull/%d" % (config.repository, n)
 
-def formulate_review(report_status, report_url, master_hash, branch_hash, interpreter, testcommand, build_docs, build_docs_command, user):
+def formulate_review(report_status, report_url, master_hash, branch_hash,
+                     interpreter, testcommand, build_docs, build_docs_command,
+                     user, branch_name, master_commit):
     if user:
         atuser = "@"+user+": "
+        branch_name = user + '/' + branch_name
     else:
         atuser = ""
 
+    if master_commit == 'origin/master':
+        master_name = 'master'
+    else:
+        master_name = "**" + master_commit + "**"
+
+    formatdict = {'branch_hash': branch_hash, 'master_hash': master_hash,
+                  'atuser': atuser, 'master_name': master_name, 'branch_name':
+                  branch_name, 'master_name': master_name}
+
     if any([status == "conflicts" for status in report_status.itervalues()]):
-        summary = """:exclamation: There were merge conflicts; could not test the branch.
+        summary = """:exclamation: There were merge conflicts (could not \
+merge {branch_name} ({branch_hash}) into {master_name} ({master_hash})); could \
+not test the branch.
 
-%sPlease rebase or merge your branch with master.  \
-See the report for a list of the merge conflicts.""" % atuser
+{atuser}Please rebase or merge your branch with master.  \
+See the report for a list of the merge conflicts."""
     elif any([status == "fetch" for status in report_status.itervalues()]):
-        summary = """:x: Could not fetch the branch.
+        summary = """:x: Could not fetch the branch {branch_name}.
 
-%sPlease run the sympy-bot tests again.""" % atuser
+{atuser}Please make sure that {branch_name} has been pushed to GitHub and run the \
+sympy-bot tests again."""
     elif any([status == "Failed" for status in report_status.itervalues()]):
-        summary = """:red_circle: There were test failures.
+        summary = """:red_circle: There were test failures (merged \
+{branch_name} ({branch_hash}) into {master_name} ({master_hash})).
 
-%sPlease fix the test failures.""" % atuser
+{atuser}Please fix the test failures."""
     elif all([status == "Passed" for status in report_status.itervalues()]):
-        summary = """:eight_spoked_asterisk: All tests have passed."""
+        summary = """:eight_spoked_asterisk: All tests have passed (merged \
+{branch_name} ({branch_hash}) into {master_name} ({master_hash}))."""
     else:
         raise ValueError("Unknown report_status")
 
 
-    report = """**SymPy Bot Summary:** %s\n\n""" % summary
+    report = """**[SymPy Bot](https://github.com/sympy/sympy-bot) Summary**: %s\n\n""" % summary
 
     for n, i in enumerate(interpreter, start=1):
         status = report_status[i]
-        if status == "conflicts":
-            summary = """:exclamation: There were merge conflicts; could not test the branch."""
-        elif status == "fetch":
-            summary = """:x: Could not fetch the branch."""
-        elif status == "Failed":
-            summary = """:red_circle: There were test failures."""
-        elif status == "Passed":
-            summary = """:eight_spoked_asterisk: All tests have passed."""
-        else:
-            raise ValueError("Unknown report_status")
+        summary = get_summary(status, report_url[i])
 
-        details = get_platform_version(i)
-        if testcommand != default_testcommand:
-            bold = "**"
+        if status in {"conflicts", "fetch"}:
+            # This is irrelevant in this case
+            details = ""
         else:
-            bold = ""
-        details += """*Test command:* %s%s%s\n""" % (bold, testcommand, bold)
-        details += """*master hash*: %s\n""" % master_hash[i]
-        details += """*branch hash*: %s\n""" % branch_hash[i]
+            details = get_platform_version(i)
+            if testcommand != default_testcommand:
+                details += """*Test command:* **%s**\n""" % testcommand
 
-        if len(interpreter) > 1:
-            report += """**Interpreter %d:** %s\n\n""" % (n, summary)
+        report += """**Interpreter %d**: %s\n""" % (n, summary)
         report += "%s\n" % details
-        report += """Test results html report: %s\n\n""" % report_url[i]
 
     if build_docs:
         status = report_status["build_docs"]
-        if status == "conflicts":
-            summary = """:exclamation: There were merge conflicts; could not test the branch."""
-        elif status == "fetch":
-            summary = """:x: Could not fetch the branch."""
-        elif status == "Failed":
-            summary = """:red_circle: There were test failures."""
-        elif status == "Passed":
-            summary = """:eight_spoked_asterisk: All tests have passed."""
-        else:
-            raise ValueError("Unknown report_status")
+        summary = get_summary(status, report_url['build_docs'])
 
         details = get_sphinx_version()
         if build_docs_command != default_build_docs_command:
-            bold = "**"
-        else:
-            bold = ""
-        details += """*Docs build command:* %s%s%s\n""" % (bold, build_docs_command, bold)
-        details += """*master hash*: %s\n""" % master_hash["build_docs"]
-        details += """*branch hash*: %s\n""" % branch_hash["build_docs"]
+            details += """*Docs build command:* **%s**\n""" % build_docs_command
 
-        report += """**Build HTML Docs:** %s\n\n""" % summary
+        report += """**Build HTML Docs:** %s\n""" % summary
         report += """%s\n""" % details
-        report += """Test results html report: %s\n\n""" % report_url["build_docs"]
 
-    report += """Automatic review by [SymPy Bot](https://github.com/sympy/sympy-bot)."""
-    return report
+    return report.format(**formatdict)
+
+def get_summary(status, report_url):
+    if status == "conflicts":
+        summary = """:exclamation: There were [merge conflicts]({report_url}); could not test the branch."""
+    elif status == "fetch":
+        summary = """:x: Could not [fetch the branch]({report_url})."""
+    elif status == "Failed":
+        summary = """:red_circle: There were test [failures]({report_url})."""
+    elif status == "Passed":
+        summary = """:eight_spoked_asterisk: All tests have [passed]({report_url})."""
+    else:
+        raise ValueError("Unknown report_status")
+    return summary.format(report_url=report_url)
 
 if __name__ == "__main__":
     main()

--- a/sympy-bot
+++ b/sympy-bot
@@ -13,7 +13,7 @@ from utils.github import (github_add_comment_to_pull_request,
         github_authenticate, github_get_pull_request, github_get_user_info,
         github_list_pull_requests)
 from utils.reviews import reviews_sympy_org_upload
-from utils.testrunner import run_tests, get_hashes, merge_branch
+from utils.testrunner import run_tests, get_hashes, merge_branch, fetch_branch
 from utils.url_templates import URLs
 
 default_testcommand = "setup.py test"
@@ -289,16 +289,19 @@ def dispatch_reviews(config, urls, **kwargs):
         author = "\"%s\" <%s>" % (user_info.get("name", "unknown"),
                                   user_info.get("email", ""))
 
-        mergeinfo = merge_branch(repo_url, branch, repo_path,
-                                 config.master_commit, n)
-        if mergeinfo["result"] == 'fetch':
-            # These values shouldn't be used anyway
-            hashinfo = {"master_hash": None, "branch_hash": None}
+        fetchinfo = fetch_branch(repo_url, branch, repo_path, n)
+        if fetchinfo:
+            mergeinfo = {"result": fetchinfo, "log": ""}
+            # This shouldn't be used anyway
+            hashinfo = {"master_hash": "", "branch_hash": ""}
         else:
+            # XXX: This has to go before merge_branch, or else it will return
+            # the merged commit SHA1 instead of the branch SHA1.
             hashinfo = get_hashes(repo_path, config.master_commit, n)
-        if not hashinfo:
-            print "> There was an error. Report not uploaded."
-            sys.exit(1)
+            if not hashinfo:
+                print "> There was an error. Report not uploaded."
+                sys.exit(1)
+            mergeinfo = merge_branch(repo_path, config.master_commit)
 
         branch_hashes[n] = hashinfo['branch_hash']
         master_hashes[n] = hashinfo['master_hash']

--- a/sympy-bot
+++ b/sympy-bot
@@ -460,19 +460,16 @@ def formulate_review(report_status, report_url, master_hash, branch_hash,
                   'atuser': atuser, 'master_name': master_name, 'branch_name':
                   branch_name, 'master_name': master_name}
 
-    skipdetails = False # TODO: Also skip redundant testing above
     if any([status == "conflicts" for status in report_status.itervalues()]):
         summary = """:exclamation: There were merge conflicts (could not \
 merge {branch_name} ({branch_hash}) into {master_name} ({master_hash})); could \
 not test the branch.
 {atuser}Please rebase or merge your branch with master.  \
 See the report for a list of the merge conflicts."""
-        skipdetails = True
     elif any([status == "fetch" for status in report_status.itervalues()]):
         summary = """:x: Could not fetch the branch {branch_name}.
 {atuser}Please make sure that {branch_name} has been pushed to GitHub and run the \
 sympy-bot tests again."""
-        skipdetails = True
     elif any([status == "Failed" for status in report_status.itervalues()]):
         summary = """:red_circle: There were test failures (merged \
 {branch_name} ({branch_hash}) into {master_name} ({master_hash})).
@@ -486,36 +483,35 @@ sympy-bot tests again."""
 
     report = """**[SymPy Bot][sympy-bot] Summary**: %s\n""" % summary
 
-    if not skipdetails:
-        for n, i in enumerate(interpreter, start=1):
-            status = report_status[i]
-            summary = get_summary(status, report_url[i])
+    for n, i in enumerate(interpreter, start=1):
+        status = report_status[i]
+        summary = get_summary(status, report_url[i])
 
-            if status in {"conflicts", "fetch"}:
-                # This is irrelevant in this case
-                # XXX: We can't use defaultdict here, as it has no effect on
-                # format(**details).  Any way we can get the same sort of thing?
-                details = {
-                    'executable': "",
-                    'python_version': "",
-                    'platform_system': "",
-                    'architecture': "",
-                    'use_cache': "",
-                    'additional_info': "",
-                }
-            else:
-                details = get_platform_version(i)
-                if testcommand != default_testcommand:
-                    details['additional_info'] += "\n*Test command:* **%s**" % testcommand
-                if details['use_cache'] != 'yes':
-                    details['additional_info'] += "\n*Cache:* **%s**" % details['use_cache']
+        if status in {"conflicts", "fetch"}:
+            # This is irrelevant in this case
+            # XXX: We can't use defaultdict here, as it has no effect on
+            # format(**details).  Any way we can get the same sort of thing?
+            details = {
+                'executable': "",
+                'python_version': "",
+                'platform_system': "",
+                'architecture': "",
+                'use_cache': "",
+                'additional_info': "",
+            }
+        else:
+            details = get_platform_version(i)
+            if testcommand != default_testcommand:
+                details['additional_info'] += "\n*Test command:* **%s**" % testcommand
+            if details['use_cache'] != 'yes':
+                details['additional_info'] += "\n*Cache:* **%s**" % details['use_cache']
 
-            details['summary'] = summary
-            details['status'] = status
-            details['symbol'] = status_symbols[status]
-            report += "{symbol} **Python {python_version}**: {summary}{additional_info}\n".format(**details)
+        details['summary'] = summary
+        details['status'] = status
+        details['symbol'] = status_symbols[status]
+        report += "{symbol} **Python {python_version}**: {summary}{additional_info}\n".format(**details)
 
-    if build_docs and not skipdetails:
+    if build_docs:
         details = get_sphinx_version()
         details['status'] = report_status["build_docs"]
         details['symbol'] = status_symbols[details['status']]

--- a/sympy-bot
+++ b/sympy-bot
@@ -315,6 +315,8 @@ def dispatch_reviews(config, urls, **kwargs):
 
         pull_review = {}
 
+        run2to3 = True
+
         # Iterate over interpreters
         for log_num, i in enumerate(interpreters):
             # Run tests
@@ -324,7 +326,9 @@ def dispatch_reviews(config, urls, **kwargs):
                 result = mergeinfo
             else:
                 result = run_tests(repo_url, branch, repo_path, command,
-                    python3[i], config.master_commit)
+                    python3[i], config.master_commit, run2to3=run2to3)
+                if python3[i]:
+                    run2to3 = False
             if result["result"] == "error":
                 print "> There was an error. Report not uploaded."
                 sys.exit(1)

--- a/sympy-bot
+++ b/sympy-bot
@@ -507,6 +507,8 @@ sympy-bot tests again."""
                 details = get_platform_version(i)
                 if testcommand != default_testcommand:
                     details['additional_info'] += "\n*Test command:* **%s**" % testcommand
+                if details['use_cache'] != 'yes':
+                    details['additional_info'] += "\n*Cache:* **%s**" % details['use_cache']
 
             details['summary'] = summary
             details['status'] = status

--- a/sympy-bot
+++ b/sympy-bot
@@ -375,8 +375,8 @@ def dispatch_reviews(config, urls, **kwargs):
                     print "> No tests to run, exiting"
                     exit()
             else:
-                repo_path = os.path.join(tmpdir, "sympy", config.build_docs_dir)
-                result = run_tests(repo_url, branch, repo_path,
+                docs_repo_path = os.path.join(tmpdir, "sympy", config.build_docs_dir)
+                result = run_tests(repo_url, branch, docs_repo_path,
                         config.build_docs_command, False, config.master_commit)
                 if result["result"] == "error":
                     print "There was an error. Report not uploaded."

--- a/sympy-bot
+++ b/sympy-bot
@@ -458,16 +458,19 @@ def formulate_review(report_status, report_url, master_hash, branch_hash,
                   'atuser': atuser, 'master_name': master_name, 'branch_name':
                   branch_name, 'master_name': master_name}
 
+    skipdetails = False # TODO: Also skip redundant testing above
     if any([status == "conflicts" for status in report_status.itervalues()]):
         summary = """:exclamation: There were merge conflicts (could not \
 merge {branch_name} ({branch_hash}) into {master_name} ({master_hash})); could \
 not test the branch.
 {atuser}Please rebase or merge your branch with master.  \
 See the report for a list of the merge conflicts."""
+        skipdetails = True
     elif any([status == "fetch" for status in report_status.itervalues()]):
         summary = """:x: Could not fetch the branch {branch_name}.
 {atuser}Please make sure that {branch_name} has been pushed to GitHub and run the \
 sympy-bot tests again."""
+        skipdetails = True
     elif any([status == "Failed" for status in report_status.itervalues()]):
         summary = """:red_circle: There were test failures (merged \
 {branch_name} ({branch_hash}) into {master_name} ({master_hash})).
@@ -481,43 +484,64 @@ sympy-bot tests again."""
 
     report = """**[SymPy Bot][sympy-bot] Summary**: %s\n""" % summary
 
-    for n, i in enumerate(interpreter, start=1):
-        status = report_status[i]
-        summary = get_summary(status, report_url[i])
+    if not skipdetails:
+        for n, i in enumerate(interpreter, start=1):
+            status = report_status[i]
+            summary = get_summary(status, report_url[i])
 
-        if status in {"conflicts", "fetch"}:
-            # This is irrelevant in this case
-            details = ""
-        else:
-            details = get_platform_version(i)
-            if testcommand != default_testcommand:
-                details += """*Test command:* **%s**\n""" % testcommand
+            if status in {"conflicts", "fetch"}:
+                # This is irrelevant in this case
+                # XXX: We can't use defaultdict here, as it has no effect on
+                # format(**details).  Any way we can get the same sort of thing?
+                details = {
+                    'executable': "",
+                    'python_version': "",
+                    'platform_system': "",
+                    'architecture': "",
+                    'use_cache': "",
+                    'additional_info': "",
+                }
+            else:
+                details = get_platform_version(i)
+                if testcommand != default_testcommand:
+                    details['additional_info'] += "\n*Test command:* **%s**" % testcommand
 
-        report += """**Interpreter %d**: %s  %s""" % (n, summary, details)
+            details['summary'] = summary
+            details['status'] = status
+            details['symbol'] = status_symbols[status]
+            report += "{symbol} **Python {python_version}**: {summary}{additional_info}\n".format(**details)
 
-    if build_docs:
-        status = report_status["build_docs"]
-        summary = get_summary(status, report_url['build_docs'])
-
+    if build_docs and not skipdetails:
         details = get_sphinx_version()
-        if build_docs_command != default_build_docs_command:
-            details += """*Docs build command:* **%s**\n""" % build_docs_command
+        details['status'] = report_status["build_docs"]
+        details['symbol'] = status_symbols[details['status']]
+        details['summary'] = get_summary(details['status'], report_url['build_docs'])
 
-        report += """**Build HTML Docs:** %s  %s\n""" % (summary, details)
+        if build_docs_command != default_build_docs_command:
+            details['additional_info'] += "\n*Docs build command:* **%s**" % build_docs_command
+
+        report += "{symbol}**Sphinx {sphinx_version}:** {summary}{additional_info}\n".format(**details)
 
     report += '''\n[sympy-bot]: https://github.com/sympy/sympy-bot "The \
 SymPy-Bot GitHub page."'''
     return report.format(**formatdict)
 
+status_symbols = {
+    "conflicts": ":exclamation:",
+    "fetch": ":x:",
+    "Failed": ":red_circle:",
+    "Passed": ":eight_spoked_asterisk:",
+}
+
 def get_summary(status, report_url):
     if status == "conflicts":
-        summary = """:exclamation: There were [merge conflicts]({report_url}); could not test the branch:"""
+        summary = "There were [merge conflicts]({report_url}); could not test the branch."
     elif status == "fetch":
-        summary = """:x: Could not [fetch the branch]({report_url}):"""
+        summary = "Could not [fetch the branch]({report_url})."
     elif status == "Failed":
-        summary = """:red_circle: There were test [failures]({report_url}):"""
+        summary = "[fail]({report_url})"
     elif status == "Passed":
-        summary = """:eight_spoked_asterisk: All tests have [passed]({report_url}):"""
+        summary = "[pass]({report_url})"
     else:
         raise ValueError("Unknown report_status")
     return summary.format(report_url=report_url)

--- a/sympy-bot
+++ b/sympy-bot
@@ -462,18 +462,15 @@ def formulate_review(report_status, report_url, master_hash, branch_hash,
         summary = """:exclamation: There were merge conflicts (could not \
 merge {branch_name} ({branch_hash}) into {master_name} ({master_hash})); could \
 not test the branch.
-
 {atuser}Please rebase or merge your branch with master.  \
 See the report for a list of the merge conflicts."""
     elif any([status == "fetch" for status in report_status.itervalues()]):
         summary = """:x: Could not fetch the branch {branch_name}.
-
 {atuser}Please make sure that {branch_name} has been pushed to GitHub and run the \
 sympy-bot tests again."""
     elif any([status == "Failed" for status in report_status.itervalues()]):
         summary = """:red_circle: There were test failures (merged \
 {branch_name} ({branch_hash}) into {master_name} ({master_hash})).
-
 {atuser}Please fix the test failures."""
     elif all([status == "Passed" for status in report_status.itervalues()]):
         summary = """:eight_spoked_asterisk: All tests have passed (merged \
@@ -482,7 +479,7 @@ sympy-bot tests again."""
         raise ValueError("Unknown report_status")
 
 
-    report = """**[SymPy Bot][sympy-bot] Summary**: %s\n\n""" % summary
+    report = """**[SymPy Bot][sympy-bot] Summary**: %s\n""" % summary
 
     for n, i in enumerate(interpreter, start=1):
         status = report_status[i]
@@ -496,8 +493,7 @@ sympy-bot tests again."""
             if testcommand != default_testcommand:
                 details += """*Test command:* **%s**\n""" % testcommand
 
-        report += """**Interpreter %d**: %s\n""" % (n, summary)
-        report += "%s\n" % details
+        report += """**Interpreter %d**: %s:  %s""" % (n, summary, details)
 
     if build_docs:
         status = report_status["build_docs"]
@@ -507,8 +503,7 @@ sympy-bot tests again."""
         if build_docs_command != default_build_docs_command:
             details += """*Docs build command:* **%s**\n""" % build_docs_command
 
-        report += """**Build HTML Docs:** %s\n""" % summary
-        report += """%s\n""" % details
+        report += """**Build HTML Docs:** %s:  %s\n""" % (summary, details)
 
     report += '''\n[sympy-bot]: https://github.com/sympy/sympy-bot "The \
 SymPy-Bot GitHub page."'''

--- a/sympy-bot
+++ b/sympy-bot
@@ -196,7 +196,7 @@ def main():
             # list of pull request numbers, convert it:
             options.n = map(int, options.n)
 
-        if not options.no_upload:
+        if not options.no_upload and options.comment:
             username, password = github_authenticate(urls, config.get("user"), config.get("password"))
         else:
             username = password = None

--- a/sympy-bot
+++ b/sympy-bot
@@ -493,7 +493,7 @@ sympy-bot tests again."""
             if testcommand != default_testcommand:
                 details += """*Test command:* **%s**\n""" % testcommand
 
-        report += """**Interpreter %d**: %s:  %s""" % (n, summary, details)
+        report += """**Interpreter %d**: %s  %s""" % (n, summary, details)
 
     if build_docs:
         status = report_status["build_docs"]
@@ -503,7 +503,7 @@ sympy-bot tests again."""
         if build_docs_command != default_build_docs_command:
             details += """*Docs build command:* **%s**\n""" % build_docs_command
 
-        report += """**Build HTML Docs:** %s:  %s\n""" % (summary, details)
+        report += """**Build HTML Docs:** %s  %s\n""" % (summary, details)
 
     report += '''\n[sympy-bot]: https://github.com/sympy/sympy-bot "The \
 SymPy-Bot GitHub page."'''
@@ -511,13 +511,13 @@ SymPy-Bot GitHub page."'''
 
 def get_summary(status, report_url):
     if status == "conflicts":
-        summary = """:exclamation: There were [merge conflicts]({report_url}); could not test the branch."""
+        summary = """:exclamation: There were [merge conflicts]({report_url}); could not test the branch:"""
     elif status == "fetch":
-        summary = """:x: Could not [fetch the branch]({report_url})."""
+        summary = """:x: Could not [fetch the branch]({report_url}):"""
     elif status == "Failed":
-        summary = """:red_circle: There were test [failures]({report_url})."""
+        summary = """:red_circle: There were test [failures]({report_url}):"""
     elif status == "Passed":
-        summary = """:eight_spoked_asterisk: All tests have [passed]({report_url})."""
+        summary = """:eight_spoked_asterisk: All tests have [passed]({report_url}):"""
     else:
         raise ValueError("Unknown report_status")
     return summary.format(report_url=report_url)

--- a/sympy-bot
+++ b/sympy-bot
@@ -17,7 +17,7 @@ from utils.testrunner import run_tests, get_hashes, merge_branch, fetch_branch
 from utils.url_templates import URLs
 
 default_testcommand = "setup.py test"
-default_build_docs_command = "make html-errors"
+default_build_docs_command = "make clean; make html-errors"
 default_interpreter = ["python"]
 default_interpreter3 = ["python3"]
 default_protocol = "https"

--- a/sympy-bot
+++ b/sympy-bot
@@ -475,7 +475,7 @@ sympy-bot tests again."""
         raise ValueError("Unknown report_status")
 
 
-    report = """**[SymPy Bot](https://github.com/sympy/sympy-bot) Summary**: %s\n\n""" % summary
+    report = """**[SymPy Bot][sympy-bot] Summary**: %s\n\n""" % summary
 
     for n, i in enumerate(interpreter, start=1):
         status = report_status[i]
@@ -503,6 +503,8 @@ sympy-bot tests again."""
         report += """**Build HTML Docs:** %s\n""" % summary
         report += """%s\n""" % details
 
+    report += '''\n[sympy-bot]: https://github.com/sympy/sympy-bot "The \
+SymPy-Bot GitHub page."'''
     return report.format(**formatdict)
 
 def get_summary(status, report_url):

--- a/utils/cmd.py
+++ b/utils/cmd.py
@@ -94,12 +94,14 @@ def get_platform_version(interpreter):
     else:
         architecture = "32-bit"
     platform_system = platform.system()
+    # TODO: This doesn't recognize bin/test -C (issue #121)
     use_cache = os.getenv('SYMPY_USE_CACHE', 'yes').lower()
     executable = get_executable(interpreter)
     python_version = get_interpreter_version_info(interpreter)
     r  = "*Interpreter:*  %s (%s)\n" % (executable, python_version)
     r += "*Architecture:* %s (%s)\n" % (platform_system, architecture)
-    r += "*Cache:*        %s\n" % use_cache
+    if use_cache != 'yes':
+        r += "*Cache:*        **%s**\n" % use_cache
     return r
 
 def get_sphinx_version():

--- a/utils/cmd.py
+++ b/utils/cmd.py
@@ -99,9 +99,13 @@ def get_platform_version(interpreter):
     executable = get_executable(interpreter)
     python_version = get_interpreter_version_info(interpreter)
     r  = "%s (%s, %s, %s)\n" % (executable, python_version, platform_system, architecture)
-    if use_cache != 'yes':
-        r += "*Cache:*        **%s**\n" % use_cache
-    return r
+    return {'executable': executable,
+            'python_version': python_version,
+            'platform_system': platform_system,
+            'architecture': architecture,
+            'use_cache': use_cache,
+            'additional_info': "",
+    }
 
 def get_sphinx_version():
     try:
@@ -109,5 +113,5 @@ def get_sphinx_version():
     except ImportError:
         return
     version = sphinx.__version__
-    r = "%s\n" % version
-    return r
+    r = " %s" % version
+    return {'sphinx_version': r, 'additional_info': ""}

--- a/utils/cmd.py
+++ b/utils/cmd.py
@@ -98,8 +98,7 @@ def get_platform_version(interpreter):
     use_cache = os.getenv('SYMPY_USE_CACHE', 'yes').lower()
     executable = get_executable(interpreter)
     python_version = get_interpreter_version_info(interpreter)
-    r  = "*Interpreter:*  %s (%s)\n" % (executable, python_version)
-    r += "*Architecture:* %s (%s)\n" % (platform_system, architecture)
+    r  = "%s (%s, %s, %s)\n" % (executable, python_version, platform_system, architecture)
     if use_cache != 'yes':
         r += "*Cache:*        **%s**\n" % use_cache
     return r
@@ -110,5 +109,5 @@ def get_sphinx_version():
     except ImportError:
         return
     version = sphinx.__version__
-    r = "*Sphinx version:* %s\n" % version
+    r = "%s\n" % version
     return r

--- a/utils/testrunner.py
+++ b/utils/testrunner.py
@@ -6,7 +6,7 @@ import subprocess
 from utils.cmd import cmd, cmd2, CmdException
 
 def run_tests(pull_request_repo_url, pull_request_branch, master_repo_path,
-              test_command, python3, master_commit):
+              test_command, python3, master_commit, run2to3=True):
     """
     This is a test runner function.
 
@@ -35,8 +35,9 @@ def run_tests(pull_request_repo_url, pull_request_branch, master_repo_path,
             "xpassed": "",
         }
     if python3:
-        use2to3 = os.path.join("bin", "use2to3")
-        cmd("python %s" % use2to3, cwd=master_repo_path)
+        if run2to3:
+            use2to3 = os.path.join("bin", "use2to3")
+            cmd("python %s" % use2to3, cwd=master_repo_path)
         master_repo_path = os.path.join(master_repo_path, "py3k-sympy")
     log, r = cmd2(test_command, cwd=master_repo_path)
     cmd("git checkout master", cwd=master_repo_path)

--- a/utils/testrunner.py
+++ b/utils/testrunner.py
@@ -40,7 +40,6 @@ def run_tests(pull_request_repo_url, pull_request_branch, master_repo_path,
             cmd("python %s" % use2to3, cwd=master_repo_path)
         master_repo_path = os.path.join(master_repo_path, "py3k-sympy")
     log, r = cmd2(test_command, cwd=master_repo_path)
-    cmd("git checkout master", cwd=master_repo_path)
     result["log"] = log
     result["return_code"] = r
 
@@ -72,22 +71,23 @@ def get_hashes(master_repo_path, master_commit, pull_request_number):
             cwd=master_repo_path).strip()
     return result
 
-def merge_branch(pull_request_repo_url, pull_request_branch, master_repo_path,
-                 master_commit, pull_request_number):
-    result = {
-        'result': "",
-        'log': "",
-    }
+def fetch_branch(pull_request_repo_url, pull_request_branch, master_repo_path,
+                 pull_request_number):
 
     try:
         cmd("git fetch %s %s:test_%s" % (pull_request_repo_url,
             pull_request_branch, pull_request_number), echo=True,
             cwd=master_repo_path)
     except CmdException:
-        result["result"] = "fetch"
-        return result
+        return "fetch"
     cmd("git checkout test_%s" % pull_request_number, echo=True, cwd=master_repo_path)
-    # remember the hashes before the merge occurs:
+
+def merge_branch(master_repo_path, master_commit):
+    # Note: this assumes the branch is already checked out
+    result = {
+        'result': "",
+        'log': "",
+    }
 
     merge_log, r = cmd2("git merge %s" % master_commit, cwd=master_repo_path)
     if r != 0:

--- a/utils/testrunner.py
+++ b/utils/testrunner.py
@@ -6,7 +6,7 @@ import subprocess
 from utils.cmd import cmd, cmd2, CmdException
 
 def run_tests(pull_request_repo_url, pull_request_branch, master_repo_path,
-        test_command, python3, master_commit):
+              test_command, python3, master_commit):
     """
     This is a test runner function.
 
@@ -33,41 +33,13 @@ def run_tests(pull_request_repo_url, pull_request_branch, master_repo_path,
     result = {
             "log": "",
             "xpassed": "",
-            "master_hash": "",
-            "branch_hash": "",
         }
-    try:
-        cmd("git fetch %s %s:test" % (pull_request_repo_url,
-            pull_request_branch), echo=True, cwd=master_repo_path)
-    except CmdException:
-        result["result"] = "fetch"
-        return result
-    cmd("git checkout test", echo=True, cwd=master_repo_path)
-    # remember the hashes before the merge occurs:
-    try:
-        result["master_hash"] = cmd("git rev-parse %s" % master_commit,
-                capture=True, cwd=master_repo_path).strip()
-    except CmdException:
-        print "Could not parse commit %s." % master_commit
-        result["result"]= "error"
-        return result
-    result["branch_hash"] = cmd("git rev-parse test", capture=True,
-            cwd=master_repo_path).strip()
-
-    merge_log, r = cmd2("git merge %s" % master_commit, cwd=master_repo_path)
-    if r != 0:
-        conflicts = cmd("git --no-pager diff", capture=True,
-                cwd=master_repo_path)
-        result["result"] = "conflicts"
-        result["log"] = merge_log + "\nLIST OF CONFLICTS\n" + conflicts
-        cmd("git merge --abort && git checkout master && git branch -D test", cwd=master_repo_path)
-        return result
     if python3:
         use2to3 = os.path.join("bin", "use2to3")
         cmd("python %s" % use2to3, cwd=master_repo_path)
         master_repo_path = os.path.join(master_repo_path, "py3k-sympy")
     log, r = cmd2(test_command, cwd=master_repo_path)
-    cmd("git checkout master && git branch -D test", cwd=master_repo_path)
+    cmd("git checkout master", cwd=master_repo_path)
     result["log"] = log
     result["return_code"] = r
 
@@ -86,3 +58,41 @@ def get_xpassed_info_from_log(log):
         lines = m.group('xpassed')
         return lines.splitlines()
     return []
+
+def get_hashes(master_repo_path, master_commit, pull_request_number):
+    result = {}
+    try:
+        result["master_hash"] = cmd("git rev-parse %s" % master_commit,
+                capture=True, cwd=master_repo_path).strip()
+    except CmdException:
+        print "Could not parse commit %s." % master_commit
+        return None
+    result["branch_hash"] = cmd("git rev-parse test_%s" % pull_request_number, capture=True,
+            cwd=master_repo_path).strip()
+    return result
+
+def merge_branch(pull_request_repo_url, pull_request_branch, master_repo_path,
+                 master_commit, pull_request_number):
+    result = {
+        'result': "",
+        'log': "",
+    }
+
+    try:
+        cmd("git fetch %s %s:test_%s" % (pull_request_repo_url,
+            pull_request_branch, pull_request_number), echo=True,
+            cwd=master_repo_path)
+    except CmdException:
+        result["result"] = "fetch"
+        return result
+    cmd("git checkout test_%s" % pull_request_number, echo=True, cwd=master_repo_path)
+    # remember the hashes before the merge occurs:
+
+    merge_log, r = cmd2("git merge %s" % master_commit, cwd=master_repo_path)
+    if r != 0:
+        conflicts = cmd("git --no-pager diff", capture=True,
+                cwd=master_repo_path)
+        result["result"] = "conflicts"
+        result["log"] = merge_log + "\nLIST OF CONFLICTS\n" + conflicts
+        cmd("git merge --abort && git checkout master", cwd=master_repo_path)
+    return result


### PR DESCRIPTION
This pull request refactors SymPy-Bot a little bit.

Two chief things were done here (unfortunately it would have been too much work to split them into separate commits):
1. SymPy-Bot now avoids doing redundant things more than once.  In particular, for each pull request, the merge is attempted only once, and use2to3 is run only once.  Note that py3k-sympy is not cleared between pull requests either, which might potentially create false positive test failures, at least until SymPy issue 3344 is fixed.  Also, the branch that is tested is now called test_N, where N is the number of the pull request (like test_123).  The branch is not deleted when the tests are done, so if you want, you can checkout the temporary directory and test things.
2. The review summaries have been greatly condensed.  Redundant information (i.e., branch hashes) is shown only once at the top, in a clearer English format that now gives the branch names and was inspired by Travis-Bot. Default information, such as the test command, is only shown if it differs from the default.  Finally, all url links are now placed inline with the text.  The result is a comment summary that I believe not only takes up significantly less space on the pull request page, but is also easier to read.

Finally, as one additional note, SymPy-Bot now officially only runs in Python 2.7.  This was so that I could use Python 2.7 idioms like set literals and dictionary comprehensions that make the code easier to read (and Python 2.6 support was dubious anyway).

Please, please, **please** test this before merging it.  As I noted, it refactors quite a bit of the core logic.  I've tried to test all possible code paths, but I'm sure I've missed something.  
