### PR TITLE
Handle stdout encoding different from utf8.

### DIFF
--- a/sympy-bot
+++ b/sympy-bot
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+import codecs
 import shutil
 import stat
 import sys
@@ -475,7 +476,7 @@ def dispatch_reviews(config, urls, **kwargs):
 
             # Log results
             log_file = os.path.join(log_dir, "interpreter-%s" % log_num)
-            with open(log_file, "w") as log:
+            with codecs.open(log_file, "w", encoding="utf8") as log:
                 log.write(result["log"])
             print "> Results logged to %s" % log_file
 
@@ -521,7 +522,7 @@ def dispatch_reviews(config, urls, **kwargs):
 
             # Log results
             log_file = os.path.join(log_dir, "docs")
-            with open(log_file, "w") as log:
+            with codecs.open(log_file, "w", encoding="utf8") as log:
                 log.write(result["log"])
             print "> Results logged to %s" % log_file
 

--- a/utils/cmd.py
+++ b/utils/cmd.py
@@ -26,6 +26,8 @@ def cmd(s, cwd=None, capture=False, ok_exit_code_list=[0], echo=False):
     p = subprocess.Popen(s, shell=True, stdout=out, stderr=subprocess.STDOUT,
             cwd=cwd)
     output = p.communicate()[0]
+    if output:
+        output = output.decode(sys.stdout.encoding)
     r = p.returncode
     if r not in ok_exit_code_list:
         raise CmdException("Command '%s' failed with err=%d. %s" % (s, r, output))
@@ -50,6 +52,7 @@ def cmd2(cmd, cwd=None):
         sys.stdout.write(char)
         sys.stdout.flush()
     log = log + p.communicate()[0]
+    log = log.decode(sys.stdout.encoding)
     r = p.returncode
 
     return log, r


### PR DESCRIPTION
This is especially important when pretty printing tests fail and we have non-ascii characters in the log. With this patch we avoid an UnicodeEncodeError that prevents the review from being uploaded.

For example I needed this patch to upload the result at https://github.com/sympy/sympy/issues/1517#issuecomment-8093378
