### PR TITLE
SymPy bot does not recognize when a "pull request" is really an issue

### DIFF
--- a/sympy-bot
+++ b/sympy-bot
@@ -416,6 +416,9 @@ def dispatch_reviews(config, urls, **kwargs):
 
         # Write pull request info
         pull = github_get_pull_request(urls, n)
+        if not pull:
+            # Pull request is really an issue
+            continue
         assert pull["number"] == n
         print "> Reviewing pull request #%d" % n
         repo_url = pull["head"]["repo"]["html_url"]

--- a/utils/url_templates.py
+++ b/utils/url_templates.py
@@ -12,6 +12,8 @@ class URLs(object):
         self.authorize_url = authorize_url
 
         self.pull_list_url = api_url + "/repos" + "/" + user + "/" + repo + "/pulls"
+        self.issue_list_url = api_url + "/repos/" + user + "/" + repo + "/issues"
+        self.single_issue_template = self.issue_list_url + "/%d"
         self.single_pull_template = self.pull_list_url + "/%d"
         self.user_info_template = api_url + "/users/%s"
         self.issue_comment_template = \


### PR DESCRIPTION
If you try `sympy-bot review 1733`, it will just hang, because https://github.com/sympy/sympy/issues/1733 is an issue that someone opened.  
