### PR TITLE
Factor out time doubling retry logic into a single function, keep_trying()

### DIFF
--- a/utils/cmd.py
+++ b/utils/cmd.py
@@ -170,7 +170,14 @@ def keep_trying(command, errors, what_did, on_except=None):
     second. If it fails again, it tries again in two seconds, then four
     seconds, and so on (doubling each time).
 
-    The return value is the same as the return value of `command()`.
+    This "time doubling" scheme mimics other systems such as the Google
+    AppEngine uploader and GMail, and is useful to give fast response time for
+    minor blips, but avoids DoSing the server, which can often make the
+    problem worse (e.g., if the reason the request failed is that you hit a
+    quota).
+
+    The return value is the same as the return value of `command()`, or
+    `on_except()` if that was run and returned non-None.
 
     """
     timer = 1

--- a/utils/cmd.py
+++ b/utils/cmd.py
@@ -2,7 +2,7 @@ import os
 import platform
 import subprocess
 import sys
-
+import time
 
 class CmdException(Exception):
     pass
@@ -144,3 +144,49 @@ def get_sphinx_version():
     version = sphinx.__version__
     r = " %s" % version
     return {'sphinx_version': r, 'additional_info': ""}
+
+def keep_trying(command, errors, what_did, on_except=None):
+    """
+    Keep trying command, using a time doubling scheme.
+
+    Parameters
+    ----------
+    command - A function with no arguments to be called.  If it's just one
+        line, use something like lambda: do_something().
+
+    errors - A list of errors to catch, like (URLError,).
+
+    what_did - A string representing what the function is doing, for use in
+        the error message.  It should be in past tense, and not start with a
+        capital letter. For example, "get pull request 1234".
+
+    on_except - (Optional) A function to be run when the exception is run,
+        before the error message is caught.  Should be a function that takes a
+        single argument, the error that was caught.  If the function returns a
+        non-None value, that is returned.  Otherwise, it retries.
+
+    It tries `command()`, and if it raises one of the errors in `errors`, it
+    prints an error message based on `what_did`, then tries again in one
+    second. If it fails again, it tries again in two seconds, then four
+    seconds, and so on (doubling each time).
+
+    The return value is the same as the return value of `command()`.
+
+    """
+    timer = 1
+
+    while True:
+        try:
+            result = command()
+            break
+        except errors as e:
+            if on_except:
+                a = on_except(e)
+                if a is not None:
+                    return a
+
+            print "Could not %s, retrying in %d seconds..." % (what_did, timer)
+            time.sleep(timer)
+            timer *= 2
+
+    return result

--- a/utils/github.py
+++ b/utils/github.py
@@ -34,8 +34,8 @@ def github_get_pull_request_all(urls):
     """
     Returns all github pull requests.
     """
-    return _query(urls.pull_list_url)
-
+    return keep_trying(lambda: _query(urls.pull_list_url), urllib2.URLError,
+                       "get list of all pull requests")
 
 def github_get_pull_request(urls, n):
     """

--- a/utils/github.py
+++ b/utils/github.py
@@ -5,6 +5,7 @@ import time
 import urllib2
 from getpass import getpass
 
+from utils.cmd import keep_trying
 
 class AuthenticationFailed(Exception):
     pass
@@ -43,59 +44,30 @@ def github_get_pull_request(urls, n):
     url = urls.single_pull_template % n
     issue_url = urls.single_issue_template % n
 
-    timer = 1
-    while True:
+    def _check_issue(e):
+        """
+        It's possible the "pull request" is really an issue. If it is, the
+        issue url will exist.
+        """
         try:
-            pull = _query(url)
-            break
+            issue = _query(issue_url)
         except urllib2.URLError:
-            # It's possible the "pull request" is really an issue.  If it is,
-            # the issue url will exist.
-            try:
-                issue = _query(issue_url)
-            except urllib2.URLError:
-                pass
-            else:
-                print "Pull request %d is just an issue (no code is attached). Skipping." % n
-                pull = False
-                break
+            pass
+        else:
+            print ("Pull request %d appears to be an issue "
+                   "(no code is attached). Skipping..." % n)
+            return False
 
-            print "Could not get pull request %d, retrying in %d seconds..." % (n, timer)
-            time.sleep(timer)
-            timer *= 2
-
-    return pull
-
+    return keep_trying(lambda: _query(url), urllib2.URLError,
+                       "get pull request %d" % n, _check_issue)
 
 def github_get_user_info(urls, username):
     url = urls.user_info_template % username
-    timer = 1
-    while True:
-        try:
-            user_info = _query(url)
-            break
-        except urllib2.URLError:
-            print "Could not get user information, retrying in %d seconds..." % timer
-            time.sleep(timer)
-            timer *= 2
-
-    return user_info
-
+    return keep_trying(lambda: _query(url), urllib2.URLError, "get user information")
 
 def github_get_user_repos(urls, username):
     url = urls.user_repos_template % username
-    timer = 1
-    while True:
-        try:
-            user_repos = _query(url)
-            break
-        except urllib2.URLError:
-            print "Could not get user repository information, retrying in %d seconds..." % timer
-            time.sleep(timer)
-            timer *= 2
-
-    return user_repos
-
+    return keep_trying(lambda: _query(url), urllib2.URLError, "get user repository information")
 
 def github_check_authentication(urls, username, password, token):
     """

--- a/utils/reviews.py
+++ b/utils/reviews.py
@@ -49,8 +49,6 @@ def reviews_sympy_org_upload(data, url_base):
     def _handler(e):
         if e.message == "Quota":
             print "Server appears to be over quota."
-        else:
-            raise e
 
     r = keep_trying(_do_upload, urllib2.URLError, "access %s" %
                     url_base, _handler)

--- a/utils/reviews.py
+++ b/utils/reviews.py
@@ -36,9 +36,7 @@ def reviews_sympy_org_upload(data, url_base):
         s = JSONRPCService(url_base + "/async")
         r = s.RPC.upload_task(data["num"], data["result"],
                 data["interpreter"], data["testcommand"], data["log"])
-        if "task_url" in r:
-            break
-        else:
+        if "task_url" not in r:
             # This happens for example when the server is over quota, see
             # https://github.com/sympy/sympy-bot/issues/110
 


### PR DESCRIPTION
See the docstring of keep_trying() for more information.  The basic idea is
   that the function tries something, and if one of the given exceptions is
   raised, it prints an error message, sleeps, and then tries again.  The time
   slept doubles with each failure, in order to prevent DoS.  It also supports
   doing additional error handling when the error is caught.

   Note that I haven't tested all the behavior yet.  In particular, I am
   currently at my GitHub API quota, so I can't test that the code to fail
   gracefully when a pull request is really an issue works.  If someone can
   try `sympy-bot review 1778` with this, that should tell you.

   I also didn't test that it does the right thing if the reviews site is over
   quota, though I probably should.  I'm not sure what the best way to test
   that would be.
