### PR TITLE
Use public_repo instead of repo when generating OAuth token

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ information on your own, you can add the following line::
 
 You can create this token from the command line by running::
 
-    curl -u 'username' -d '{"scopes":["repo"],"note":"SymPy Bot"}' \
+    curl -u 'username' -d '{"scopes":["public_repo"],"note":"SymPy Bot"}' \
     https://api.github.com/authorizations
 
 and enter your password at the prompt. In the information that is printed,

--- a/utils/github.py
+++ b/utils/github.py
@@ -20,7 +20,7 @@ https to authenticate with GitHub, otherwise not saved anywhere else:\
 def generate_token(urls, username, password, name="SymPy Bot"):
     enc_data = json.dumps(
         {
-            "scopes": ["repo"],
+            "scopes": ["public_repo"],
             "note": name
         }
     )


### PR DESCRIPTION
I don't see a reason why SymPy Bot should have access to private repositories.
